### PR TITLE
WIP: add upload configurability

### DIFF
--- a/conda_concourse_ci/bootstrap/config/uploads.d/anaconda-example.yml
+++ b/conda_concourse_ci/bootstrap/config/uploads.d/anaconda-example.yml
@@ -1,0 +1,3 @@
+token: some-token
+user: some-optional-user-OK-to-omit
+label: some-optional-label-OK-to-omit

--- a/conda_concourse_ci/bootstrap/config/uploads.d/custom-example.yml
+++ b/conda_concourse_ci/bootstrap/config/uploads.d/custom-example.yml
@@ -1,0 +1,1 @@
+command: "ls -lR"

--- a/conda_concourse_ci/bootstrap/config/uploads.d/scp-example.yml
+++ b/conda_concourse_ci/bootstrap/config/uploads.d/scp-example.yml
@@ -1,0 +1,6 @@
+server: your-server
+destination_path: "test-pkgs-someuser/{subdir}"
+auth_dict:
+  user: username-for-login
+  key: path-or-private-key-text  # optional; can apply to just username/password login, or key to access ssh key.
+  password: optional-applies-to-either-user-or-key

--- a/conda_concourse_ci/build_matrix.py
+++ b/conda_concourse_ci/build_matrix.py
@@ -3,12 +3,11 @@ import contextlib
 from itertools import product
 import os
 
-from conda_build.api import render
 import six
 import yaml
 
 
-def load_platforms(platforms_dir):
+def load_yaml_config_dir(platforms_dir):
     platforms = []
     for f in os.listdir(platforms_dir):
         if f.endswith('.yml'):

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -145,7 +145,12 @@ def bootstrap():
     _copy_yaml_if_not_there('config/config.yml')
     # create platform.d folders
     for run_type in ('build', 'test'):
-        _copy_yaml_if_not_there('config/{0}_platforms.d/example.yml'.format(run_type))
+        if not os.path.exists('config/{0}_platforms.d'.format(run_type)):
+            _copy_yaml_if_not_there('config/{0}_platforms.d/example.yml'.format(run_type))
+    if not os.path.exists('config/uploads.d'):
+        _copy_yaml_if_not_there('config/uploads.d/anaconda-example.yml')
+        _copy_yaml_if_not_there('config/uploads.d/scp-example.yml')
+        _copy_yaml_if_not_there('config/uploads.d/custom-example.yml')
     # create basic versions.yml files
     _copy_yaml_if_not_there('config/versions.yml')
     # create initial plan that runs c3i to determine further plans

--- a/conda_concourse_ci/compute_build_graph.py
+++ b/conda_concourse_ci/compute_build_graph.py
@@ -123,7 +123,11 @@ def add_recipe_to_graph(recipe_dir, graph, run, env_var_set, worker, conda_resol
     if run == 'build':
         add_recipe_to_graph(recipe_dir, graph, 'test', env_var_set, worker, conda_resolve,
                             recipes_dir=recipes_dir)
-        graph.add_edge(package_key('test', metadata, worker['label']), name)
+        test_key = package_key('test', metadata, worker['label'])
+        graph.add_edge(test_key, name)
+        upload_key = package_key('upload', metadata, worker['label'])
+        graph.add_node(upload_key, meta=metadata, env=env_var_set, worker=worker)
+        graph.add_edge(upload_key, test_key)
 
     return name
 

--- a/conda_concourse_ci/uploads.py
+++ b/conda_concourse_ci/uploads.py
@@ -1,17 +1,49 @@
+"""
+for the sake of simplicity, all uploads are done with a linux worker, whose capabilities are
+well known and understood.  This file is dedicated to helpers to write tasks for that linux
+worker
+
+Each function here returns a list of task dictionaries.  This is because some tasks (scp) need
+to run additional tasks (for example, to update the index on the remote side)
+"""
+
+import json
 import logging
-import os
-import subprocess
+# import os
+# import subprocess
 
-import paramiko
-from paramiko_scp import SCPClient
-import six
+from conda_build.utils import package_has_file
+# import paramiko
+# from paramiko_scp import SCPClient
+# import six
 
-from .build_matrix import load_platforms
+from .build_matrix import load_yaml_config_dir
 
 log = logging.getLogger(__file__)
 
 
-def upload_anaconda(package, token, user=None, label=None):
+def _get_package_subdir(package):
+    index = json.load(package_has_file(package, 'info/index.json'))
+    return index['subdir']
+
+
+def get_upload_job_name(test_job_name, upload_job_name):
+    return test_job_name.replace('test', 'upload') + '-' + upload_job_name
+
+
+def _base_task(test_job_name, upload_job_name):
+    return {'task': upload_job_name,
+            'config': {
+                'inputs': [{'name': test_job_name}],
+                'image_resource': {
+                    'type': 'docker-image',
+                    'source': {'repository': 'msarahan/conda-concourse-ci'}},
+                'platform': 'linux',
+                'run': {}
+            }}
+
+
+def upload_anaconda(test_job_name, token, user=None, label=None):
     """
     Upload to anaconda.org using a token.  Tokens are associated with a channel, so the channel
     need not be specified.  You may specify a label to install to a label other than main.
@@ -19,56 +51,103 @@ def upload_anaconda(package, token, user=None, label=None):
     Instructions for generating a token are at:
         https://docs.continuum.io/anaconda-cloud/managing-account#using-tokens
     """
-    cmd = ['anaconda', '--token', token, 'upload']
+    cmd = ['--token', token, '--force', 'upload']
+    identifier = token[-4:]
     if user:
         cmd.extend(['--user', user])
+        identifier = user
     if label:
         cmd.extend(['--label', label])
-    cmd.append(package)
-    subprocess.check_call(cmd)
+    upload_job_name = get_upload_job_name(test_job_name, 'anaconda-' + identifier)
+    task = _base_task(test_job_name, upload_job_name)
+    task['config']['run'].update({'path': 'anaconda', 'args': cmd})
+    return [{upload_job_name, task}]
 
 
-def upload_scp(package, server, destination_path, port=22, key_var=None, user_password_var=None):
+def upload_scp(test_job_name, server, destination_path, auth_dict, port=22):
     """
     Upload using scp (using paramiko).  Authentication can be done via key or username/password.
 
-    For key authentication, store your desired private key as text in a secret environment variable
-       on Concourse CI.  Provide the name of that variable as the key_var argument here.  A temporary
-       in-memory file will be wrtten and fed to paramiko for authentication.
+    destination_path should have a placeholder for the platform/arch subdir.  For example:
 
-    For user, provide username and password, separated by a colon in a secret environment variable
-      on Concourse CI, and provide the name of that variable here.
+       destination_path = "test-pkgs-someuser/{subdir}"
+
+    auth_dict needs either:
+
+        key: the private key to use for the connection.  Can be either a path to a file locally, or
+            text of the key itself.
+        password: optional password for provided key.  If not provided, assumed to be empty.
+
+        user: the username to log in with
+        password: the password for the user
 
     This tries to call conda index on the remote side after uploading.  Otherwise, the new
       package would be unavailable.
     """
-    with paramiko.SSHClient() as ssh:
-        ssh.set_missing_host_key_policy(
-            paramiko.AutoAddPolicy())
-        if user_password_var:
-            user, password = os.getenv(user_password_var).split(":")
-            ssh.connect(server, port=port, username=user, password=password)
-        elif key_var:
-            key = six.StringIO(os.getenv(key_var))
-            key = paramiko.RSAKey.from_private_key(key)
-            ssh.connect(server, pkey=key)
-        with SCPClient(ssh.get_transport()) as scp:
-            scp.put(package, destination_path)
-        if destination_path.endswith(os.path.splitext(package)[1]):
-            destination_path = os.path.dirname(destination_path)
-        try:
-            ssh.exec_command('conda index {0}'.format(destination_path))
-        except paramiko.SSHException as e:
-            log.warn("Conda index failed on remote end (%s) for %s", server, package)
-            log.warn(str(e))
+    identifier = server
+    task = _base_task(test_job_name, 'scp-' + identifier)
+
+    raise NotImplementedError
+    # with paramiko.SSHClient() as ssh:
+    #     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    #     if 'user' in auth_dict:
+    #         ssh.connect(server, port=port, username=auth_dict['user'],
+    #                     password=auth_dict['password'])
+    #     elif 'key' in auth_dict:
+    #         if os.path.exists(os.path.expanduser(auth_dict['key'])):
+    #             key = open(auth_dict['key']).read()
+    #         else:
+    #             key = auth_dict['key']
+    #         key = six.StringIO(key)
+    #         key = paramiko.RSAKey.from_private_key(key, password=auth_dict.get('password'))
+    #         ssh.connect(server, pkey=key)
+    #     else:
+    #         raise ValueError("Neither user nor key provided to scp auth_dict.  Aborting.")
+    #     with SCPClient(ssh.get_transport()) as scp:
+    #         scp.put(package, destination_path)
+    #     if destination_path.endswith(os.path.splitext(package)[1]):
+    #         destination_path = os.path.dirname(destination_path)
+
+    #     # get package subdir from the package itself, rather than trying to pass it through steps
+    #     subdir = _get_package_subdir(package)
+
+    #     try:
+    #         ssh.exec_command('conda index {0}'.format(destination_path.format(subdir)))
+    #     except paramiko.SSHException as e:
+    #         log.warn("Conda index failed on remote end (%s) for %s", server, package)
+    #         log.warn(str(e))
 
 
-def upload_command(package, command):
+def upload_command(package, test_job_name, command):
     """Execute an arbitrary upload command.  Input string is expected to have a placeholder for
     the package to upload.  For example:
 
     command = "scp {package} someuser@someserver:somefolder"
 
+    package is the filename of the output package, only.  Subfoldering is handled with the
+    test_job_name.
     """
-    command = command.format(package=package).split()
-    subprocess.check_call(command)
+    raise NotImplementedError
+    # command = command.format(package=os.path.join(test_job_name, package)).split()
+    # # TODO: need to finish this
+    # task = _base_task(test_job_name, 'custom')
+
+    # task['config']['run'].update({'path': command[0], 'args': command[1:]})
+    # return [task]
+
+
+def get_upload_tasks(package_path, upload_config_dir):
+    tasks = []
+    configurations = load_yaml_config_dir(upload_config_dir)
+
+    for config in configurations:
+        if 'token' in config:
+            tasks.extend(upload_anaconda(package_path, **config))
+        elif 'server' in config:
+            tasks.extend(upload_scp(package_path, **config))
+        elif 'command' in config:
+            tasks.extend(upload_command(package_path, **config))
+        else:
+            raise ValueError("Unrecognized upload configuration.  Each file needs one of: "
+                             "'token', 'server', or 'command'")
+    return tasks

--- a/tests/test_build_matrix.py
+++ b/tests/test_build_matrix.py
@@ -28,8 +28,8 @@ test_data_dir = os.path.join(os.path.dirname(__file__), 'data')
 #     assert len(configurations) == 4
 
 
-def test_load_platforms():
-    platforms = bm.load_platforms(os.path.join(test_data_dir, 'build_platforms.d'))
+def test_load_yaml_config_dir():
+    platforms = bm.load_yaml_config_dir(os.path.join(test_data_dir, 'build_platforms.d'))
     assert len(platforms) == 3
     assert 'label' in platforms[0]
     assert 'platform' in platforms[0]

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -21,7 +21,8 @@ def test_collect_tasks(mocker, testing_conda_resolve, testing_graph):
                                        matrix_base_dir=test_data_dir)
     test_platforms = os.listdir(os.path.join(test_data_dir, 'test_platforms.d'))
     build_platforms = os.listdir(os.path.join(test_data_dir, 'build_platforms.d'))
-    n_platforms = len(test_platforms) + len(build_platforms)
+    # one build, one test per platform, uploads only for builds.
+    n_platforms = len(test_platforms) + 2 * len(build_platforms)
     # minimum args means build and test provided folders.  Two tasks.
     assert len(task_graph.nodes()) == n_platforms
 
@@ -39,10 +40,12 @@ def test_get_plan_text(mocker, testing_graph):
                   'params': {'version': '{{version}}'}},
                  execute._extract_task('1.0.0'),
                  execute._ls_task,
-                 {'aggregate': [{'task': 'build-b-0-linux',
-                                 'file': 'extracted-archive/output/build-b-0-linux.yml'}]},
-                 {'aggregate': [{'task': 'test-b-0-linux',
-                                 'file': 'extracted-archive/output/test-b-0-linux.yml'}]}
+                 {'task': 'build-b-0-linux',
+                  'file': 'extracted-archive/output/build-b-0-linux.yml'},
+                 {'task': 'test-b-0-linux',
+                  'file': 'extracted-archive/output/test-b-0-linux.yml'},
+                 {'task': 'upload-b-0-linux',
+                  'file': 'extracted-archive/output/upload-b-0-linux.yml'}
              ]
             }
         ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -98,6 +98,8 @@ def testing_graph(request):
                worker=default_worker)
     g.add_node('test-b-0-linux', meta=default_metadata('b'), env={}, worker=default_worker)
     g.add_edge('test-b-0-linux', 'build-b-0-linux')
+    g.add_node('upload-b-0-linux', meta=default_metadata('b'), env={}, worker=default_worker)
+    g.add_edge('upload-b-0-linux', 'test-b-0-linux')
     return g
 
 


### PR DESCRIPTION
This adds another configuration folder to support flexible upload schemes.

At the time of writing, only anaconda.org is fleshed out.  The key to these upload schemes is that the upload needs to be a separate task from build and test.

This PR still needs to:

- [ ] Copy the output package from build to test, and from test to upload
- [ ] flesh out scp support - work out secure scheme for handling required keys
- [ ] flesh out custom command support.  Especially - how does one chain multiple commands together
- [ ] tests for each