### PR TITLE
use conda-build's get_build_index function rather than conda's get_index

### DIFF
--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -18,7 +18,7 @@ b_hash = 'b-hd248202_0-linux'
 
 def test_collect_tasks(mocker, testing_conda_resolve, testing_graph):
     mocker.patch.object(execute, 'Resolve')
-    mocker.patch.object(execute, 'get_index')
+    mocker.patch.object(execute, 'get_build_index')
     mocker.patch.object(conda_concourse_ci.compute_build_graph, '_installable')
     execute.Resolve.return_value = testing_conda_resolve
     conda_concourse_ci.compute_build_graph._installable.return_value = True


### PR DESCRIPTION
The hope is that this will allow the package resolving process to respect condarc.  It may also be faster due to caching on the conda-build side.