### PR TITLE
Make runtime deps of CDT pkgs part of the container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,22 @@ RUN mkdir -p bin && \
   ARTIFACT_URL="https://github.com/concourse/concourse/releases/download/$LATEST_VERSION/fly_linux_amd64" && \
   curl -L ${ARTIFACT_URL} -o bin/fly && chmod +x bin/fly
 
-RUN yum install -y util-linux openssh-clients rsync wget patch
+RUN yum install -y \
+  libX11 \
+  libXau \
+  libXcb \
+  libXdmcp \
+  libXext \
+  libXrender \
+  libXt \
+  mesa-libGL \
+  mesa-libGLU \
+  openssh-clients \
+  patch \
+  rsync \
+  util-linux \
+  wget \
+  && yum clean all
 
 WORKDIR /build_scripts
 COPY install_miniconda.sh /build_scripts


### PR DESCRIPTION
This is required for running tests which involve libraries
linking to libx11.so

cc @msarahan @mingwandroid 