### PR TITLE
don't remove master node when folding subpackages into master

### DIFF
--- a/conda_concourse_ci/compute_build_graph.py
+++ b/conda_concourse_ci/compute_build_graph.py
@@ -343,7 +343,8 @@ def collapse_subpackage_nodes(graph):
 
                 # remove nodes that have been folded into master nodes
                 for subnode in subpackages:
-                    graph.remove_node(subnode)
+                    if subnode != master_key:
+                        graph.remove_node(subnode)
 
 
 def construct_graph(recipes_dir, worker, run, conda_resolve, folders=(),


### PR DESCRIPTION
This bug manifested itself when a top-level package name matched a subpackage.
The subpackage would be eliminated, leaving no packages to build at all.