### PR TITLE
fix identification of 'master' recipe for collapsing subpackages

### DIFF
--- a/conda_concourse_ci/compute_build_graph.py
+++ b/conda_concourse_ci/compute_build_graph.py
@@ -302,7 +302,9 @@ def collapse_subpackage_nodes(graph):
             meta = graph.node[node]['meta']
             meta_path = meta.meta_path or meta.meta['extra']['parent_recipe']['path']
             master = False
-            if meta.meta_path:
+
+            master_meta = MetaData(meta_path, config=meta.config)
+            if master_meta.name() == meta.name():
                 master = True
             group = node_groups.get(meta_path, {})
             subgroup = group.get(HashableDict(meta.config.variant), {})

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -532,7 +532,7 @@ def compute_builds(path, base_name, git_rev=None, stop_rev=None, folders=None, m
         if meta.meta_path:
             recipe = os.path.dirname(meta.meta_path)
         else:
-            recipe = meta.get('extra', {}).get('parent_recipe', {})
+            recipe = meta.meta.get('extra', {}).get('parent_recipe', {}).get('path', '')
         assert recipe, ("no parent recipe set, and no path associated "
                                 "with this metadata")
         # make recipe path relative


### PR DESCRIPTION
If an output had the same name as the top-level recipe, collapsing subpackages was breaking.  This may have been due to recent conda-build changes, which changed the way that outputs are determined from the recipe.