### PR TITLE
fix loss of variables due to unfinalized data omitting hash from keys

### DIFF
--- a/tests/data/win_split_outputs_compiler_reduction/conda_build_config.yaml
+++ b/tests/data/win_split_outputs_compiler_reduction/conda_build_config.yaml
@@ -1,0 +1,165 @@
+pin_run_as_build:
+  libboost:
+    max_pin: x.x.x
+
+apr:
+  - 1.6.3
+blas_impl:
+  - mkl                        # [x86 or x86_64]
+  - openblas
+boost:
+  - 1.65
+bzip2:
+  - 1.0
+cairo:
+  - 1.14
+c_compiler:
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+cxx_compiler:
+  - vs2008                     # [win]
+  - vs2015                     # [win]
+  - vs2015                     # [win]
+fortran_compiler:
+  - intel-fortran              # [win]
+fortran_compiler_version:
+  - 13.1.6                     # [win]
+  - 16.0.4                     # [win]
+  - 16.0.4                     # [win]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.9.sdk        # [osx]
+VERBOSE_AT:
+  - V=1
+VERBOSE_CM:
+  - VERBOSE=1
+dbus:
+  - 1
+expat:
+  - 2.2                # [not ppc64le]
+fontconfig:
+  - 2.12
+freetype:
+  - 2.8                # [not ppc64le]
+g2clib:
+  - 1.6
+gstreamer:
+  - 1.12
+gst_plugins_base:
+  - 1.12
+geos:
+  - 3.6.2
+giflib:
+  - 5.1
+glib:
+  - 2.53
+gmp:
+  - 6.1
+harfbuzz:
+  - 1.7
+hdf4:
+  - 4.2
+hdf5:
+  - 1.8                # [not ppc64le]
+  - 1.10               # [not ppc64le]
+hdfeos2:
+  - 2.19
+hdfeos5:
+  - 5.1
+icu:
+  - 58                 # [not ppc64le]
+ipython:
+  - 5.4                # [not ppc64le]
+  - 5.3                    # [ppc64le]
+  - 6.1
+  - 6.1
+jpeg:
+  - 9
+libdap4:
+  - 3.19
+libffi:
+  - 3.2
+libgdal:
+  - 2.2
+libgsasl:
+  - 1.8
+libkml:
+  - 1.3
+libnetcdf:
+  - 4.4
+libpng:
+  - 1.6
+libtiff:
+  - 4.0
+libxml2:
+  - 2.9
+libxslt:
+  - 1.1
+lzo:
+  - 2
+macos_min_version:
+  - 10.9
+macos_machine:
+  - x86_64-apple-darwin13.4.0
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.9
+mkl:
+  - 2018
+mpfr:
+  - 3
+# we build for an old version of numpy for forward compatibility
+#    1.11 seems to be the oldest on win that works with scipy 0.19.  Compiler errors otherwise.
+numpy:
+  - 1.9   # [unix]
+  - 1.11   # [win]
+openblas:
+  - 0.2.20
+openjpeg:
+  - 2.2
+openssl:
+  - 1.0.2
+perl:
+  - 5.26
+pixman:
+  - 0.34
+proj4:
+  - 4
+protobuf:
+  - 3.3
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+scipy:
+  - 0.19
+serf:
+  - 1.3.9
+sqlite:
+  - 3
+# This differs from target_platform in that it determines what subdir the compiler
+#    will target, not what subdir the compiler package will be itself.
+#    For example, we need a win-64 vs2008_win-32 package, so that we compile win-32
+#    code on win-64 miniconda.
+cross_compiler_target_platform:
+  - win-32                     # [win]
+  - win-64                     # [win]
+target_platform:
+  - win-64                     # [win]
+  - win-32                     # [win]
+tk:
+  - 8.6                # [not ppc64le]
+vc:
+  - 9
+  - 14
+  - 14
+zlib:
+  - 1.2
+xz:
+  - 5
+zip_keys:
+  -                             # [win]
+    - vc                        # [win]
+    - c_compiler                # [win]
+    - cxx_compiler              # [win]
+    - fortran_compiler_version  # [win]
+    - python                    # [win]

--- a/tests/data/win_split_outputs_compiler_reduction/meta.yaml
+++ b/tests/data/win_split_outputs_compiler_reduction/meta.yaml
@@ -1,0 +1,95 @@
+{% set version = "10.1" %}
+{% set sha256 = "3ccb4e25fe7a7ea6308dea103cac202963e6b746697366d72ec2900449a5e713" %}
+{% set libpqver = '.'.join(("5", version.split('.')[0])) %}
+
+package:
+  name: postgresql-split
+  version: {{ version }}
+
+source:
+  fn: postgresql-{{ version }}.tar.bz2
+  url: https://ftp.postgresql.org/pub/source/v{{ version }}/postgresql-{{ version }}.tar.bz2
+  sha256: {{ sha256 }}
+  patches:
+    - 0001-fix-win-zlib-and-openssl-lib-names.patch  # [win]
+
+build:
+  number: 0
+
+requirements:
+  build:
+    - {{ compiler('c') }}
+    - m2-bison         # [win]
+    - m2-diffutils     # [win]
+    - m2-flex          # [win]
+    # perl pinned to older version due to issues with @INC not being recursive or something like that.
+    - perl  5.20.*     # [win]
+    - posix            # [win]
+  host:
+    - krb5             # [not osx]
+    - openssl
+    - readline         # [not win]
+    - zlib
+
+outputs:
+  - name: postgresql
+    requirements:
+      build:
+        # solely for sake of lining up vc versions and other runtimes
+        - {{ compiler('c') }}
+      host:
+        # these are here for sake of run_exports taking effect
+        - krb5             # [not osx]
+        - openssl
+        - readline         # [not win]
+        - zlib
+        - {{ pin_subpackage('libpq', exact=True) }}
+      run:
+        - {{ pin_subpackage('libpq', exact=True) }}
+    test:
+      commands:
+        - postgres --help
+        - conda inspect linkages postgresql  # [not win]
+        - conda inspect objects postgresql  # [osx]
+    about:
+      summary: 'PostgreSQL is a powerful, open source object-relational database system.'
+
+  - name: libpq
+    build:
+      run_exports:
+        - {{ pin_subpackage('libpq') }}
+    requirements:
+      build:
+        # solely for sake of lining up vc versions and other runtimes
+        - {{ compiler('c') }}
+      host:
+        # these are here for sake of run_exports taking effect
+        - krb5     # [not osx]
+        - openssl
+        - readline         # [not win]
+        - zlib
+    test:
+      commands:
+        - pg_config
+        - test -f $PREFIX/lib/libpq.so.{{ libpqver }}      # [linux]
+        - test -f $PREFIX/lib/libpq.so.5                   # [linux]
+        - test -f $PREFIX/lib/libpq.so                     # [linux]
+        - test -f $PREFIX/lib/libpq.{{ libpqver }}.dylib   # [osx]
+        - test -f $PREFIX/lib/libpq.5.dylib                # [osx]
+        - test -f $PREFIX/lib/libpq.dylib                  # [osx]
+        - IF NOT EXIST %LIBRARY_BIN%\libpq.dll EXIT 1      # [win]
+        - IF NOT EXIST %LIBRARY_BIN%\pg_config.exe EXIT 1  # [win]
+    about:
+      summary: The postgres runtime libraries and utilities (not the server itself)
+
+about:
+  home: http://www.postgresql.org/
+  license: PostgreSQL
+  license_file: COPYRIGHT
+
+extra:
+  recipe-maintainers:
+    - gillins
+    - msarahan
+    - ocefpaf
+    - mariusvniekerk

--- a/tests/test_compute_build_graph.py
+++ b/tests/test_compute_build_graph.py
@@ -42,9 +42,9 @@ def test_construct_graph_relative_path(testing_git_repo, testing_conda_resolve):
 
 def test_package_key(testing_metadata):
     assert (compute_build_graph.package_key(testing_metadata, 'linux') ==
-            'test_package_key-1.0-python3.6-on-linux')
+            'test_package_key-1.0-python_3.6-on-linux')
     assert (compute_build_graph.package_key(testing_metadata, 'linux', 'test') ==
-            'c3itest-test_package_key-1.0-python3.6-on-linux')
+            'c3itest-test_package_key-1.0-python_3.6-on-linux')
 
 
 def test_platform_specific_graph(mocker, testing_conda_resolve):
@@ -385,5 +385,5 @@ def test_version_matching(testing_conda_resolve):
                                             matrix_base_dir=test_config_dir,
                                             conda_resolve=testing_conda_resolve)
     assert len(g.nodes()) == 4
-    assert ('downstream-1.0-upstream1.0-on-linux', 'upstream-1.0.1-on-linux') in g.edges()
-    assert ('downstream-1.0-upstream2.0-on-linux', 'upstream-2.0.2-on-linux') in g.edges()
+    assert ('downstream-1.0-upstream_1.0-on-linux', 'upstream-1.0.1-on-linux') in g.edges()
+    assert ('downstream-1.0-upstream_2.0-on-linux', 'upstream-2.0.2-on-linux') in g.edges()

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -140,10 +140,10 @@ def test_compute_builds(testing_workdir, mocker, monkeypatch):
     files = os.listdir(output)
     assert 'plan.yml' in files
 
-    assert os.path.isfile(os.path.join(output, 'frank-1.0-python2.7-on-centos5-64', 'meta.yaml'))
-    assert os.path.isfile(os.path.join(output, 'frank-1.0-python2.7-on-centos5-64/', 'conda_build_config.yaml'))
-    assert os.path.isfile(os.path.join(output, 'frank-1.0-python3.6-on-centos5-64', 'meta.yaml'))
-    assert os.path.isfile(os.path.join(output, 'frank-1.0-python3.6-on-centos5-64/', 'conda_build_config.yaml'))
+    assert os.path.isfile(os.path.join(output, 'frank-1.0-python_2.7-on-centos5-64', 'meta.yaml'))
+    assert os.path.isfile(os.path.join(output, 'frank-1.0-python_2.7-on-centos5-64/', 'conda_build_config.yaml'))
+    assert os.path.isfile(os.path.join(output, 'frank-1.0-python_3.6-on-centos5-64', 'meta.yaml'))
+    assert os.path.isfile(os.path.join(output, 'frank-1.0-python_3.6-on-centos5-64/', 'conda_build_config.yaml'))
     assert os.path.isfile(os.path.join(output, 'dummy_conda_forge_test-1.0-on-centos5-64', 'meta.yaml'))
     with open(os.path.join(output, 'dummy_conda_forge_test-1.0-on-centos5-64/', 'conda_build_config.yaml')) as f:
         cfg = f.read()
@@ -195,8 +195,8 @@ def test_python_build_matrix_expansion(monkeypatch):
     tasks = execute.collect_tasks('.', matrix_base_dir=os.path.join(test_data_dir, 'linux-config-test'),
                                   folders=['python_test'])
     assert len(tasks.nodes()) == 2
-    assert 'frank-1.0-python2.7-on-centos5-64' in tasks.nodes()
-    assert 'frank-1.0-python3.6-on-centos5-64' in tasks.nodes()
+    assert 'frank-1.0-python_2.7-on-centos5-64' in tasks.nodes()
+    assert 'frank-1.0-python_3.6-on-centos5-64' in tasks.nodes()
 
 
 def test_subpackage_matrix_no_subpackages(monkeypatch):
@@ -223,8 +223,20 @@ def test_dependency_with_selector_cross_compile(testing_conda_resolve):
                               variant_config_files=os.path.join(test_data_dir, 'conda_build_config.yaml'))
     assert len(g.nodes()) == 6
     # native edge
-    assert ('test_run_deps_with_selector-1.0-python2.7-on-win-64',
-            'functools32-3.2.3.2-python2.7-on-win-64') in g.edges()
+    assert ('test_run_deps_with_selector-1.0-python_2.7-on-win-64',
+            'functools32-3.2.3.2-python_2.7-on-win-64') in g.edges()
     # cross edge
-    assert ('test_run_deps_with_selector-1.0-python2.7target-win-32-on-win-64',
-            'functools32-3.2.3.2-python2.7target-win-32-on-win-64') in g.edges()
+    assert ('test_run_deps_with_selector-1.0-python_2.7-target_win-32-on-win-64',
+            'functools32-3.2.3.2-python_2.7-target_win-32-on-win-64') in g.edges()
+
+
+def test_collapse_with_win_matrix_and_subpackages(monkeypatch):
+    monkeypatch.chdir(test_data_dir)
+    tasks = execute.collect_tasks('.', matrix_base_dir=os.path.join(test_data_dir, 'config-win'),
+                                  folders=['win_split_outputs_compiler_reduction'])
+    # 8 subpackages, but 4 total builds - 2 subpackages per build
+    assert len(tasks.nodes()) == 4
+    assert 'postgresql-split-10.1-c_compiler_vs2008-on-win-64' in tasks.nodes()
+    assert 'postgresql-split-10.1-c_compiler_vs2015-on-win-64' in tasks.nodes()
+    assert 'postgresql-split-10.1-c_compiler_vs2008-target_win-32-on-win-64' in tasks.nodes()
+    assert 'postgresql-split-10.1-c_compiler_vs2015-target_win-32-on-win-64' in tasks.nodes()


### PR DESCRIPTION
This relies on recent CB3 improvements to say what "used" variables are.  That code should only exist in CB3.  It also changes the package key from the collection of packages (which should ideally reflect variants) to the combination of package names with variants.  It's more direct and less error-prone.

CC @jjhelmus @nehaljwani 