### PR TITLE
allow storage of config dir; specify platform names with glob pattern

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,11 @@ install:
   - conda config --set always_yes yes
   - conda config --set auto_update_conda False
   - conda update -q --all
-  - conda install -q requests python=$TRAVIS_PYTHON_VERSION pyflakes flake8 mock six
-  - conda install -q pytest-cov 'networkx<2' boto3 git
+  - conda install -q requests python=$TRAVIS_PYTHON_VERSION pyflakes flake8 mock six psutil
+  - if [[ "$TRAVIS_PYTHON_VERSION" == "2.7" ]]; then
+      conda install -q scandir;
+    fi
+  - conda install -q pytest-cov 'networkx<2' git
   - pushd ..
   # take care of c-b's dependencies
   - conda install -q conda-build

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from conda_concourse_ci import execute, __version__
+from conda_build.conda_interface import cc_conda_build
 
 
 def parse_args(parse_this=None):
@@ -38,11 +39,17 @@ def parse_args(parse_this=None):
     examine_parser.add_argument('--test', action='store_true',
                         help='test packages (instead of building AND testing them)')
     examine_parser.add_argument('--matrix-base-dir',
-                        help='path to matrix configuration, if different from recipe path')
+                                help='path to matrix configuration, if different from recipe path',
+                                default=cc_conda_build.get('matrix_base_dir'))
     examine_parser.add_argument('--output-dir', help="folder where output plan and recipes live",
                                 default='../output')
     examine_parser.add_argument('--channel', '-c', action='append',
                                 help="Additional channel to use when building packages")
+    examine_parser.add_argument('--platform-filter', '-p', action='append',
+                                help="glob pattern(s) to filter build platforms.  For example, "
+                                "linux* will build all platform files whose filenames start with "
+                                "linux",
+                                dest='platform_filters')
     examine_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",
@@ -80,12 +87,17 @@ def parse_args(parse_this=None):
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),
                                 help="path containing recipe folders to upload")
     one_off_parser.add_argument('--config-root-dir',
-                                help="path containing config.yml and matrix definitions")
+                                help="path containing config.yml and matrix definitions",
+                                default=cc_conda_build.get('matrix_base_dir'))
     one_off_parser.add_argument('--private', action='store_false',
                         help='hide build logs (overall graph still shown in Concourse web view)',
                         dest='public')
     one_off_parser.add_argument('--channel', '-c', action='append',
                                 help="Additional channel to use when building packages")
+    one_off_parser.add_argument('--platform-filter', '-p', action='append',
+                                help="glob pattern(s) to filter build platforms.  For example, "
+                                "linux* will build all platform files whose filenames start with "
+                                "linux", dest='platform_filters')
     one_off_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",

--- a/conda_concourse_ci/utils.py
+++ b/conda_concourse_ci/utils.py
@@ -1,4 +1,6 @@
+import fnmatch
 import os
+
 import six
 import yaml
 
@@ -14,10 +16,10 @@ def ensure_list(arg):
     return arg
 
 
-def load_yaml_config_dir(platforms_dir):
+def load_yaml_config_dir(platforms_dir, platform_filters):
     platforms = []
     for f in os.listdir(platforms_dir):
-        if f.endswith('.yml'):
+        if f.endswith('.yml') and any(fnmatch.fnmatch(f, pat) for pat in platform_filters):
             with open(os.path.join(platforms_dir, f)) as buff:
                 platforms.append(yaml.load(buff))
     return platforms

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,11 +28,11 @@ def test_submit_one_off(mocker):
     args = ['one-off', 'frank', 'bzip2', '--config-root-dir', '../config']
     cli.main(args)
     cli.execute.submit_one_off.assert_called_once_with(pipeline_label='frank',
-                                                       config_root_dir='../config', debug=False,
+                                                       config_root_dir=mocker.ANY, debug=False,
                                                        public=True, recipe_root_dir=os.getcwd(),
                                                        subparser_name='one-off', folders=['bzip2'],
                                                        channel=None, variant_config_files=None,
-                                                       output_dir=None)
+                                                       output_dir=None, platform_filters=None)
 
 
 def test_submit_without_base_name_raises():
@@ -60,11 +60,12 @@ def test_examine(mocker):
     args = ['examine', 'frank']
     cli.main(args)
     cli.execute.compute_builds.assert_called_once_with(base_name='frank', debug=False, folders=[],
-                                                       git_rev='HEAD', matrix_base_dir=None,
+                                                       git_rev='HEAD', matrix_base_dir=mocker.ANY,
                                                        max_downstream=5, output_dir='../output',
                                                        path='.', steps=0, stop_rev=None,
                                                        subparser_name='examine', test=False,
-                                                       channel=None, variant_config_files=None)
+                                                       channel=None, variant_config_files=None,
+                                                       platform_filters=None)
 
 
 def test_examine_without_base_name_raises():


### PR DESCRIPTION
This allows you to save a default config dir to your condarc, like this:

```
conda_build:
  matrix_base_dir: ~/code/automated-build/c3i_configurations/anaconda_public
```

And it'll by default use all configurations in that folder.  Now, if you want to restrict it, you can also add glob patterns at the CLI:

``c3i one-off mcs_test click-feedstock -p "linux*"``

will build only platforms whose filename starts with linux