### PR TITLE
set locale in ppc64le docker container

### DIFF
--- a/docker/c3i-linux-ppc64le/Dockerfile
+++ b/docker/c3i-linux-ppc64le/Dockerfile
@@ -1,5 +1,10 @@
 FROM ppc64le/centos:7
 
+# Set the locale
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 RUN yum install -y \
   libX11 \
   libXau \


### PR DESCRIPTION
Some Python 3 command line utilities, including those which use click, require
that a unicode supporting locale be set.