### PR TITLE
add gettext to docker image

### DIFF
--- a/docker/c3i-linux-64/Dockerfile
+++ b/docker/c3i-linux-64/Dockerfile
@@ -13,6 +13,7 @@ RUN mkdir -p bin && \
   curl -L ${ARTIFACT_URL} -o bin/fly && chmod +x bin/fly
 
 RUN yum install -y \
+  gettext gettext.i686 \
   libX11 libX11.i686 \
   libXau libXau.i686 \
   libXcb libXcb.i686 \


### PR DESCRIPTION
Bumped into ``msgfmt`` missing when trying to build glib.  Ray recommends that gettext is so fundamental, it should be part of the image.