### PR TITLE
Fix cycle output

### DIFF
--- a/conda_concourse_ci/compute_build_graph.py
+++ b/conda_concourse_ci/compute_build_graph.py
@@ -524,8 +524,7 @@ def order_build(graph):
         order = list(nx.topological_sort(graph))
         order.reverse()
     except nx.exception.NetworkXUnfeasible:
-        raise ValueError("Cycles detected in graph: %s", nx.find_cycle(graph,
-                                                                       orientation='reverse'))
+        raise ValueError("Cycles detected in graph: %s", nx.find_cycle(graph))
 
     return order
 


### PR DESCRIPTION
Traversing in reverse orientation doesn't get the same result and can miss cycles.