### PR TITLE
skip existing; implement append/clobber files

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -116,6 +116,18 @@ def parse_args(parse_this=None):
     )
     one_off_parser.add_argument('--output-dir', help=("folder where output plan and recipes live."
                                 "Defaults to temp folder.  Set to something to save output."))
+    one_off_parser.add_argument(
+        '--append-file',
+        help="""Append data in meta.yaml with fields from this file.  Jinja2 is not done
+        on appended fields""",
+        dest='append_sections_file',
+    )
+    one_off_parser.add_argument(
+        '--clobber-file',
+        help="""Clobber data in meta.yaml with fields from this file.  Jinja2 is not done
+        on clobbered fields.""",
+        dest='clobber_sections_file',
+    )
 
     rm_parser = sp.add_parser('rm', help='remove pipelines from server')
     rm_parser.add_argument('pipeline_names', nargs="+",

--- a/tests/data/functools32-feedstock/recipe/meta.yaml
+++ b/tests/data/functools32-feedstock/recipe/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: functools32
+  name: functools32_wannabe
   version: "3.2.3.2"
 
 source:

--- a/tests/data/intradependencies/uses_zlib/meta.yaml
+++ b/tests/data/intradependencies/uses_zlib/meta.yaml
@@ -4,4 +4,4 @@ package:
 
 requirements:
   build:
-    - zlib
+    - zlib_wannabe

--- a/tests/data/intradependencies/zlib/meta.yaml
+++ b/tests/data/intradependencies/zlib/meta.yaml
@@ -1,7 +1,7 @@
 # this is a dummy package to make sure that we correctly create the build tree
 
 package:
-  name: zlib
+  name: zlib_wannabe
   version: 1.2.8
 
 build:

--- a/tests/data/selector_run/meta.yaml
+++ b/tests/data/selector_run/meta.yaml
@@ -7,4 +7,4 @@ requirements:
     - python
   run:
     - python
-    - functools32  # [py27]
+    - functools32_wannabe  # [py27]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,8 @@ def test_submit_one_off(mocker):
                                                        subparser_name='one-off', folders=['bzip2'],
                                                        channel=None, variant_config_files=None,
                                                        output_dir=None, platform_filters=None,
-                                                       worker_tags=None)
+                                                       worker_tags=None, clobber_sections_file=None,
+                                                       append_sections_file=None)
 
 
 def test_submit_without_base_name_raises():

--- a/tests/test_compute_build_graph.py
+++ b/tests/test_compute_build_graph.py
@@ -1,6 +1,7 @@
 import os
 
 from conda_build.metadata import MetaData
+from conda_build.api import Config
 import networkx as nx
 import pytest
 
@@ -188,7 +189,7 @@ def test_installable(testing_conda_resolve, testing_metadata):
 def test_expand_run_no_up_or_down(mocker, testing_graph, testing_conda_resolve):
     initial_length = len(testing_graph)
     # all packages are installable in the default index
-    compute_build_graph.expand_run(testing_graph, testing_conda_resolve,
+    compute_build_graph.expand_run(testing_graph, Config(), testing_conda_resolve,
                                    worker=dummy_worker, run='build')
     assert len(testing_graph) == initial_length
 
@@ -200,7 +201,7 @@ def test_expand_run_step_down(mocker, testing_graph, testing_conda_resolve):
                                             folders=('a',), run='build',
                                             matrix_base_dir=test_config_dir,
                                             conda_resolve=testing_conda_resolve)
-    compute_build_graph.expand_run(g, testing_conda_resolve,
+    compute_build_graph.expand_run(g, Config(), testing_conda_resolve,
                                    run='build', worker=dummy_worker,
                                    recipes_dir=graph_data_dir,
                                    matrix_base_dir=test_config_dir,
@@ -218,7 +219,7 @@ def test_expand_run_two_steps_down(mocker, testing_graph, testing_conda_resolve)
                                             matrix_base_dir=test_config_dir,
                                             conda_resolve=testing_conda_resolve)
 
-    compute_build_graph.expand_run(g, testing_conda_resolve,
+    compute_build_graph.expand_run(g, Config(), testing_conda_resolve,
                                    run='build', worker=dummy_worker,
                                    recipes_dir=graph_data_dir,
                                    matrix_base_dir=test_config_dir,
@@ -242,12 +243,13 @@ def test_expand_run_all_steps_down(mocker, testing_graph, testing_conda_resolve)
                                             matrix_base_dir=test_config_dir,
                                             conda_resolve=testing_conda_resolve)
 
-    compute_build_graph.expand_run(g, testing_conda_resolve,
+    compute_build_graph.expand_run(g, Config(), testing_conda_resolve,
                                    run='build', worker=dummy_worker,
                                    recipes_dir=graph_data_dir,
                                    matrix_base_dir=test_config_dir,
                                    max_downstream=-1, steps=-1)
-    assert set(g.nodes()) == {'a-1.0-on-linux', 'b-1.0-on-linux', 'c-1.0-on-linux', 'd-1.0-on-linux', 'e-1.0-on-linux'}
+    assert set(g.nodes()) == {'a-1.0-on-linux', 'b-1.0-on-linux', 'c-1.0-on-linux',
+                              'd-1.0-on-linux', 'e-1.0-on-linux'}
 
 
 def test_expand_run_all_steps_down_with_max(mocker, testing_conda_resolve):
@@ -258,7 +260,7 @@ def test_expand_run_all_steps_down_with_max(mocker, testing_conda_resolve):
                                             matrix_base_dir=test_config_dir,
                                             conda_resolve=testing_conda_resolve)
 
-    compute_build_graph.expand_run(g, testing_conda_resolve,
+    compute_build_graph.expand_run(g, Config(), testing_conda_resolve,
                                    run='build', worker=dummy_worker,
                                    recipes_dir=graph_data_dir,
                                    matrix_base_dir=test_config_dir,
@@ -274,12 +276,12 @@ def test_expand_run_build_non_installable_prereq(mocker, testing_conda_resolve):
                                             matrix_base_dir=test_config_dir,
                                             conda_resolve=testing_conda_resolve)
 
-    compute_build_graph.expand_run(g, testing_conda_resolve,
+    compute_build_graph.expand_run(g, Config(), testing_conda_resolve,
                                    run='build', worker=dummy_worker,
                                    recipes_dir=graph_data_dir)
     assert set(g.nodes()) == {'a-1.0-on-linux', 'b-1.0-on-linux'}
 
-    compute_build_graph.expand_run(g, testing_conda_resolve,
+    compute_build_graph.expand_run(g, Config(), testing_conda_resolve,
                                    run='build', worker=dummy_worker,
                                    recipes_dir=graph_data_dir, matrix_base_dir=test_config_dir,
                                    steps=1)

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -161,7 +161,7 @@ def test_compute_builds_intradependencies(testing_workdir, monkeypatch, mocker):
         plan = yaml.load(f)
 
     uses_zlib_job = [job for job in plan['jobs'] if job['name'] == 'uses_zlib-1.0-on-centos5-64'][0]
-    assert any(task.get('passed') == ['zlib-1.2.8-on-centos5-64']
+    assert any(task.get('passed') == ['zlib_wannabe-1.2.8-on-centos5-64']
                for task in uses_zlib_job['plan'])
 
 
@@ -211,10 +211,10 @@ def test_dependency_with_selector_cross_compile(testing_conda_resolve):
     assert len(g.nodes()) == 6
     # native edge
     assert ('test_run_deps_with_selector-1.0-python_2.7-on-win-64',
-            'functools32-3.2.3.2-python_2.7-on-win-64') in g.edges()
+            'functools32_wannabe-3.2.3.2-python_2.7-on-win-64') in g.edges()
     # cross edge
     assert ('test_run_deps_with_selector-1.0-python_2.7-target_win-32-on-win-64',
-            'functools32-3.2.3.2-python_2.7-target_win-32-on-win-64') in g.edges()
+            'functools32_wannabe-3.2.3.2-python_2.7-target_win-32-on-win-64') in g.edges()
 
 
 def test_collapse_with_win_matrix_and_subpackages(monkeypatch):


### PR DESCRIPTION
This looks in your configured channels for existing builds, and skips them.  Maybe that will help with rebuild efforts.  It also enables using clobber and append files, with the current purpose being disabling noarch: python from conda-forge without recipe divergence.