### PR TITLE
add pass-through to cb for args not recognized by c3i

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -136,14 +136,14 @@ def parse_args(parse_this=None):
                            help="path containing config.yml and matrix definitions",
                            default=cc_conda_build.get('matrix_base_dir'))
     rm_parser.add_argument('--do-it-dammit', '-y', help="YOLO", action="store_true")
-    return parser.parse_args(parse_this)
+    return parser.parse_known_args(parse_this)
 
 
 def main(args=None):
     if not args:
-        args = parse_args()
+        args, pass_throughs = parse_args()
     else:
-        args = parse_args(args)
+        args, pass_throughs = parse_args(args)
 
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -154,15 +154,15 @@ def main(args=None):
         args_dict = args.__dict__
         if not args_dict.get('config_root_dir'):
             args_dict['config_root_dir'] = args_dict['base_name']
-        execute.submit(**args_dict)
+        execute.submit(pass_throughs=pass_throughs, **args_dict)
     elif args.subparser_name == 'bootstrap':
-        execute.bootstrap(**args.__dict__)
+        execute.bootstrap(pass_throughs=pass_throughs, **args.__dict__)
     elif args.subparser_name == 'examine':
-        execute.compute_builds(**args.__dict__)
+        execute.compute_builds(pass_throughs=pass_throughs, **args.__dict__)
     elif args.subparser_name == 'one-off':
-        execute.submit_one_off(**args.__dict__)
+        execute.submit_one_off(pass_throughs=pass_throughs, **args.__dict__)
     elif args.subparser_name == 'rm':
-        execute.rm_pipeline(**args.__dict__)
+        execute.rm_pipeline(pass_throughs=pass_throughs, **args.__dict__)
     else:
         # this is here so that if future subcommands are added, you don't forget to add a bit
         #     here to enable them.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_submit(mocker):
                                                debug=False, pipeline_file='plan_director.yml',
                                                pipeline_name='{base_name} plan director',
                                                public=True, src_dir=os.getcwd(),
-                                               subparser_name='submit')
+                                               subparser_name='submit', pass_throughs=[])
 
 
 def test_submit_one_off(mocker):
@@ -34,7 +34,7 @@ def test_submit_one_off(mocker):
                                                        channel=None, variant_config_files=None,
                                                        output_dir=None, platform_filters=None,
                                                        worker_tags=None, clobber_sections_file=None,
-                                                       append_sections_file=None)
+                                                       append_sections_file=None, pass_throughs=[])
 
 
 def test_submit_without_base_name_raises():
@@ -48,7 +48,7 @@ def test_bootstrap(mocker):
     args = ['bootstrap', 'frank']
     cli.main(args)
     cli.execute.bootstrap.assert_called_once_with(base_name='frank', debug=False,
-                                                  subparser_name='bootstrap')
+                                                  subparser_name='bootstrap', pass_throughs=[])
 
 
 def test_bootstrap_without_base_name_raises():
@@ -67,7 +67,8 @@ def test_examine(mocker):
                                                        path='.', steps=0, stop_rev=None,
                                                        subparser_name='examine', test=False,
                                                        channel=None, variant_config_files=None,
-                                                       platform_filters=None, worker_tags=None)
+                                                       platform_filters=None, worker_tags=None,
+                                                       pass_throughs=[])
 
 
 def test_examine_without_base_name_raises():


### PR DESCRIPTION
@jjhelmus this is what you proposed a long time ago.  It lets us pass things like ``--python=3.7`` to limit our builds to specific python versions.