### PR TITLE
add batch sub-command

### DIFF
--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -767,7 +767,7 @@ def submit_batch(
                 print("Exception was:", e)
                 failed.append(batch_item)
         else:
-            print("Too many active builds:", num_running_builds)
+            print("Too many active builds:", num_activate_builds)
         time.sleep(poll_time)
 
     print("one-off jobs submitted:", len(success))

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -782,7 +782,7 @@ class BatchItem(object):
 
     def __init__(self, line):
         if ';' in line:
-            folders_str, extra_str = line.split(';', maxsplit=2)
+            folders_str, extra_str = line.split(';', 2)
             extra_str = extra_str.strip()
         else:
             folders_str = line

--- a/tests/data/batch_sample.txt
+++ b/tests/data/batch_sample.txt
@@ -1,0 +1,2 @@
+pytest pytest-cov
+bzip; clobber_sections_file=example.yaml

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,18 @@ def test_submit_one_off(mocker):
                                                        append_sections_file=None, pass_throughs=[])
 
 
+def test_submit_batch(mocker):
+    mocker.patch.object(cli.execute, 'submit_batch')
+    args = ['batch', 'batch_file.txt', '--config-root-dir', '../config']
+    cli.main(args)
+    cli.execute.submit_batch.assert_called_once_with(
+        batch_file='batch_file.txt', recipe_root_dir=os.getcwd(), config_root_dir=mocker.ANY,
+        max_builds=36, poll_time=120, build_lookback=500, label_prefix='autobot_',
+        debug=False, public=True, subparser_name='batch', channel=None,
+        variant_config_files=None, output_dir=None, platform_filters=None, worker_tags=None,
+        clobber_sections_file=None, append_sections_file=None, pass_throughs=[])
+
+
 def test_submit_without_base_name_raises():
     with pytest.raises(SystemExit):
         args = ['submit']


### PR DESCRIPTION
c3i batch can be used to submit a batch of one-off jobs which are submitted
only when the number of activate jobs is below a given threshold