### PR TITLE
use new conda-index syntax

### DIFF
--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -132,8 +132,7 @@ def consolidate_task(inputs, subdir):
                      'mkdir -p indexed-artifacts/noarch \n'
                      'find . -name "indexed-artifacts" -prune -o -path "*/{subdir}/*.tar.bz2" -print0 | xargs -0 -I file mv file indexed-artifacts/{subdir}\n'  # NOQA
                      'find . -name "indexed-artifacts" -prune -o -path "*/noarch/*.tar.bz2" -print0 | xargs -0 -I file mv file indexed-artifacts/noarch\n'  # NOQA
-                     'conda-index indexed-artifacts/{subdir}\n'
-                     'conda-index indexed-artifacts/noarch\n'.format(subdir=subdir))]
+                     'conda-index indexed-artifacts\n'.format(subdir=subdir))]
         }}
     return {'task': 'update-artifact-index', 'config': task_dict}
 


### PR DESCRIPTION
conda index not longer requires that the subdir be specified.