### PR TITLE
use conda-debug (to be released in conda-build 3.17.0)

### DIFF
--- a/conda_concourse_ci/compute_build_graph.py
+++ b/conda_concourse_ci/compute_build_graph.py
@@ -22,13 +22,14 @@ hash_length = api.Config().hash_length
 
 def package_key(metadata, worker_label, run='build'):
     # get the build string from whatever conda-build makes of the configuration
+
     used_loop_vars = metadata.get_used_loop_vars()
     build_vars = '-'.join([k + '_' + str(metadata.config.variant[k]) for k in used_loop_vars
                           if k != 'target_platform'])
     # kind of a special case.  Target platform determines a lot of output behavior, but may not be
     #    explicitly listed in the recipe.
     tp = metadata.config.variant.get('target_platform')
-    if tp and tp != metadata.config.subdir and 'target_platform' not in build_vars:
+    if tp and tp != metadata.config.subdir:
         build_vars += '-target_' + tp
     key = [metadata.name(), metadata.version()]
     if build_vars:
@@ -399,6 +400,7 @@ def construct_graph(recipes_dir, worker, run, conda_resolve, folders=(),
             raise ValueError("Specified folder {} does not exist".format(recipe_dir))
         add_recipe_to_graph(recipe_dir, graph, run, worker, conda_resolve,
                             recipes_dir, config=config, finalize=finalize)
+
     add_intradependencies(graph)
     collapse_subpackage_nodes(graph)
     return graph

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -281,25 +281,25 @@ def sourceclear_task(meta, node, config_vars):
         },
         'run': {
             'path': 'sh',
-            'args': ['-exc',
-                     # srcclr requires that all dependencies are present.  To accomplish that,
-                     #   we create an env for our built package and activate that env.  Next,
-                     #   we need to extract our source code and init a git repo there.  The
-                     #   git repo is a requirement for sourceclear.  I'm not sure we'll be
-                     #   able to bypass that requirement with this hack, but we'll see.
-                     (# "find . -name 'indexed-artifacts' -prune -o -path '*/linux-64/*.tar.bz2' -print0 | xargs -0 -I file mv file indexed-artifacts/linux-64 \n"  # NOQA
-                      # "find . -name 'indexed-artifacts' -prune -o -path '*/noarch/*.tar.bz2' -print0 | xargs -0 -I file mv file indexed-artifacts/noarch \n"  # NOQA
-                      'conda-index output-artifacts \n'
-                      'export activate_cmd="$(conda-debug -a -c file://$(pwd)/output-artifacts rsync-recipes/{})"\n'
-                      'bash --rcfile <(echo ". ~/.bashrc; $activate_cmd)"\n'
-                      'echo \"system_site_packages: true\" > srcclr.yml \n'
-                      # "echo \"use_system_pip: true\" >> srcclr.yml \n'
-                      'set | grep SRCCLR \n'
-                      'ls -la \n'
-                      'curl -sSL https://download.sourceclear.com/ci.sh -o srcclr_ci.sh\n'
-                      'chmod +x srcclr_ci.sh\n'
-                      './srcclr_ci.sh\n')
-                     .format(node, ' '.join(build_args + output_files))],
+            'args': [
+                '-exc',
+                # srcclr requires that all dependencies are present.  To accomplish that,
+                #   we create an env for our built package and activate that env.  Next,
+                #   we need to extract our source code and init a git repo there.  The
+                #   git repo is a requirement for sourceclear.  I'm not sure we'll be
+                #   able to bypass that requirement with this hack, but we'll see.
+                ('conda-index output-artifacts \n '
+                 'export activation_text="$(conda-debug -a -c file://$(pwd)/output-artifacts rsync-recipes/{node})" && '
+                 'echo ". ~/.bashrc; $activation_text" > ./temp_rcfile && '
+                 'source ./temp_rcfile && '
+                 'echo "system_site_packages: true" > srcclr.yml && '
+                 # "echo \"use_system_pip: true\" >> srcclr.yml && '
+                 # 'set | grep SRCCLR && '
+                 # 'ls -la \n'
+                      'curl -sSL https://download.sourceclear.com/ci.sh -o srcclr_ci.sh && '
+                 'chmod +x srcclr_ci.sh && '
+                 './srcclr_ci.sh')
+                .format(node=node)],
         }}
     return {'task': 'sourceclear scan', 'config': task_dict}
 
@@ -352,8 +352,6 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
                   }}]
 
     rsync_resources = []
-
-    # each package is a unit in the concourse graph.  This step recombines our separate steps.
 
     for node in order:
         meta = graph.node[node]['meta']

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -290,11 +290,8 @@ def sourceclear_task(meta, node, config_vars):
                      (# "find . -name 'indexed-artifacts' -prune -o -path '*/linux-64/*.tar.bz2' -print0 | xargs -0 -I file mv file indexed-artifacts/linux-64 \n"  # NOQA
                       # "find . -name 'indexed-artifacts' -prune -o -path '*/noarch/*.tar.bz2' -print0 | xargs -0 -I file mv file indexed-artifacts/noarch \n"  # NOQA
                       "conda-index output-artifacts \n"
-                      "conda build --source --no-build-id --croot tmp_work rsync-recipes/{}\n"
-                      "conda create -y --only-deps -p $(pwd)/dummy_env "
-                      "-c file://$(pwd)/output-artifacts {}\n"
-                      "source activate $(pwd)/dummy_env \n"
-                      "pushd tmp_work/work \n"
+                      "acivation_cmd=$(conda-debug --output -c file://$(pwd)/output-artifacts rsync-recipes/{})\n"
+                      "$activation_cmd\n"
                       "echo \"system_site_packages: true\" > srcclr.yml \n"
                       # "echo \"use_system_pip: true\" >> srcclr.yml \n"
                       "set | grep SRCCLR \n"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 100
-ignore = E122,E123,E126,E127,E128,E731
+ignore = E122,E123,E126,E127,E128,E731,E124
 exclude = build,conda_concourse_ci/_version.py,tests,conda.recipe,.git
 
 [tool:pytest]


### PR DESCRIPTION
My initial way to do this was wrong.  Sourceclear needs the build-time dependencies, not the run-time dependencies.  This uses a new conda-build feature to accomplish that.