### PR TITLE
allow workers to skip noarch: python builds

### DIFF
--- a/conda_concourse_ci/compute_build_graph.py
+++ b/conda_concourse_ci/compute_build_graph.py
@@ -201,6 +201,8 @@ def add_recipe_to_graph(recipe_dir, graph, run, worker, conda_resolve,
         if (is_package_built(metadata, 'host', include_local=False) and config.skip_existing or
                 metadata.skip()):
             continue
+        if metadata.noarch == 'python' and worker.get('skip_noarch_python', False):
+            continue
 
         name = package_key(metadata, worker['label'], run)
 


### PR DESCRIPTION
Build workers can skip noarch: python build be including the line
skip_noarch_python: True
in the configuration file. At least one worker should not include this line or
else the package will not build built.