### PR TITLE
no trailing space when joining prefix/suffix cmds

### DIFF
--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -264,12 +264,12 @@ def get_build_task(base_path, graph, node, commit_id, public=True, artifact_inpu
 
     cmds = build_prefix_commands + ' conda-build ' + " ".join(build_args) + \
            ' ' + build_suffix_commands
-    prefix_commands = " && ".join(ensure_list(worker.get('prefix_commands')))
-    suffix_commands = " && ".join(ensure_list(worker.get('suffix_commands')))
+    prefix_commands = "&& ".join(ensure_list(worker.get('prefix_commands')))
+    suffix_commands = "&& ".join(ensure_list(worker.get('suffix_commands')))
     if prefix_commands:
-        cmds = prefix_commands + ' && ' + cmds
+        cmds = prefix_commands + '&& ' + cmds
     if suffix_commands:
-        cmds = cmds + ' && ' + suffix_commands
+        cmds = cmds + '&& ' + suffix_commands
 
     task_dict['run']['args'].append(cmds)
 


### PR DESCRIPTION
Join prefix and suffix commands using "&& ", do not use a trailing space.
In some scriping languages, such as batch, a trailing space can change the
behavior of a command.  The particular cases where this was observed was in the
command "set TEMP=%CD%".  When joined with a trailing space the space was added
to the TEMP variable.

See: https://superuser.com/questions/57723