### PR TITLE
Use intermediate key from vault

### DIFF
--- a/conda_concourse_ci/bootstrap/config/config.yml
+++ b/conda_concourse_ci/bootstrap/config/config.yml
@@ -9,5 +9,6 @@ recipe-repo-access-token: your-github-access-token-if-using-private-repo
 intermediate-server: your-intermediate-server
 intermediate-base-folder: /ci
 intermediate-user: your-intermediate-user
+intermediate-private-key-job: key-to-upload-to-concourse
 intermediate-private-key: |
   private-key-to-use-for-connecting-to-intermediate-server

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -399,7 +399,7 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
                       'server': config_vars['intermediate-server'],
                       'base_dir': recipe_folder,
                       'user': config_vars['intermediate-user'],
-                      'private_key': config_vars['intermediate-private-key'],
+                      'private_key': config_vars['intermediate-private-key-job'],
                       'disable_version_path': True,
                   }},
                  {'name': 'rsync-source',
@@ -408,7 +408,7 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
                       'server': config_vars['intermediate-server'],
                       'base_dir': os.path.join(config_vars['intermediate-base-folder'], 'source'),
                       'user': config_vars['intermediate-user'],
-                      'private_key': config_vars['intermediate-private-key'],
+                      'private_key': config_vars['intermediate-private-key-job'],
                       'disable_version_path': True,
                       }},
                  {'name': 'rsync-stats',
@@ -417,7 +417,7 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
                       'server': config_vars['intermediate-server'],
                       'base_dir': os.path.join(config_vars['intermediate-base-folder'], 'stats'),
                       'user': config_vars['intermediate-user'],
-                      'private_key': config_vars['intermediate-private-key'],
+                      'private_key': config_vars['intermediate-private-key-job'],
                       'disable_version_path': True,
                   }}]
 
@@ -441,7 +441,7 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
                     'base_dir': os.path.join(config_vars['intermediate-base-folder'],
                                             config_vars['base-name'], 'artifacts'),
                     'user': config_vars['intermediate-user'],
-                    'private_key': config_vars['intermediate-private-key'],
+                    'private_key': config_vars['intermediate-private-key-job'],
                     'disable_version_path': True,
                 }})
 

--- a/tests/data/config-test/config.yml
+++ b/tests/data/config-test/config.yml
@@ -9,5 +9,6 @@ base-name: test
 intermediate-server: your-intermediate-server
 intermediate-base-folder: /ci
 intermediate-user: your-intermediate-user
+intermediate-private-key-job: key-to-upload-to-concourse
 intermediate-private-key: |
   private-key-to-use-for-connecting-to-intermediate-server

--- a/tests/data/linux-config-test/config.yml
+++ b/tests/data/linux-config-test/config.yml
@@ -9,5 +9,6 @@ base-name: test
 intermediate-server: your-intermediate-server
 intermediate-base-folder: /ci
 intermediate-user: your-intermediate-user
+intermediate-private-key-job: key-to-upload-to-concourse
 intermediate-private-key: |
   private-key-to-use-for-connecting-to-intermediate-server


### PR DESCRIPTION
As per https://github.com/pivotalservices/concourse-pipeline-samples/tree/master/concourse-pipeline-patterns/vault-integration you can update jobs to use vault by just changing variables in the config file.

Since the intermediate-private-key is used elsewhere in c3i, it needs to stay in the variables config file for now. But, with this change the key won't be uploaded every time.

Example part of a build:
```
groups: []
resources:
- name: rsync-recipes
  type: rsync-resource
  source:
    base_dir: /ci/imagesize-feedstock/plan_and_recipes
    disable_version_path: true
    private_key: ((common.intermediate-private-key))
    server: bremen.corp.continuum.io
    user: ci
```

related to https://github.com/ContinuumIO/automated-build/pull/11 