### PR TITLE
do not fail job if _netrc is not written

### DIFF
--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -257,7 +257,7 @@ def get_build_task(base_path, graph, node, commit_id, public=True, artifact_inpu
             creds_cmd = ['echo machine github.com '
                               'login %GITHUB_USER% '
                               'password %GITHUB_TOKEN% '
-                              'protocol https > %USERPROFILE%\_netrc']
+                              'protocol https > %USERPROFILE%\_netrc && exit 0']
         else:
             creds_cmd = ['set +x',
                          'echo machine github.com '


### PR DESCRIPTION
Writing to the _netrc file can create a race condition if multiple builds are
scheduled on the same worker. Failing to write this file should not fail the
build although will result in private repositories not being accessable.