### PR TITLE
Another _netrc writing fix on Windows

### DIFF
--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -254,10 +254,10 @@ def get_build_task(base_path, graph, node, commit_id, public=True, artifact_inpu
             'GITHUB_TOKEN': gh_access_token
         }
         if worker['platform'] == 'win':
-            creds_cmd = ['echo machine github.com '
+            creds_cmd = ['(echo machine github.com '
                               'login %GITHUB_USER% '
                               'password %GITHUB_TOKEN% '
-                              'protocol https > %USERPROFILE%\_netrc & exit 0']
+                              'protocol https > %USERPROFILE%\_netrc || exit 0)']
         else:
             creds_cmd = ['set +x',
                          'echo machine github.com '


### PR DESCRIPTION
This has been tested and gives good results.

For reference:
"cmd1 || cmd2" will execute cmd2 if cmd1 has a non-zero errorlevel
"cmd1 && cmd2" will execute cmd2 if cmd1 has a zero errorlevel
"cmd1 & cmd2" will always xecute cmd2

Commands submitted to concourse are joined with &&. Grouping the netrc
writing commands and exit 0 with () is needed for the || to have its intended
effect.