### PR TITLE
Use a pool of locks to limit the number of concurrent build on each platform

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -137,6 +137,10 @@ def parse_args(parse_this=None):
         '--no-skip-existing', help="Do not skip existing builds",
         dest="skip_existing", action="store_false"
     )
+    one_off_parser.add_argument(
+        '--use_lock_pool', help="Use the lock pool to limit jobs",
+        dest="use_lock_pool", action="store_true"
+    )
 
     batch_parser = sp.add_parser('batch', help="submit a batch of one-off jobs.")
     batch_parser.add_argument(

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -501,10 +501,8 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
             tasks.append(consolidate_task(prereqs, meta.config.host_subdir))
 
         if use_lock_pool:
-            # one pool for each platform regardless of the arch
-            # pool = worker['platform'] + '_' + worker['arch']
-            # would use seperate pools for each platform+arch
-            pool = worker['platform']
+            # pool name is specified in configuration file
+            pool = worker['pool_name']
             lock_resource_name = pool + '_lock'
             used_pools[lock_resource_name] = pool
             aquire_lock_task = {

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -612,8 +612,13 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
                            'tag': 'latest'
                            }
                        })
+    _add_lock_pool_resources(resources, used_pools, config_vars)
+    # convert types for smoother output to yaml
+    return {'resource_types': resource_types, 'resources': resources, 'jobs': remapped_jobs}
 
-    # add lock pool resources
+
+def _add_lock_pool_resources(resources, used_pools, config_vars):
+    """ Add lock pool resources to the resources dictionary """
     for lock_resource_name, pool in used_pools.items():
         source = {
             'uri': '((lock-pool-repo))',
@@ -631,9 +636,7 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
             'source': source,
         }
         resources.append(lock_resource)
-
-    # convert types for smoother output to yaml
-    return {'resource_types': resource_types, 'resources': resources, 'jobs': remapped_jobs}
+    return
 
 
 def _get_current_git_rev(path, branch=False):

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -615,15 +615,20 @@ def graph_to_plan_with_jobs(base_path, graph, commit_id, matrix_base_dir, config
 
     # add lock pool resources
     for lock_resource_name, pool in used_pools.items():
+        source = {
+            'uri': '((lock-pool-repo))',
+            'branch': '((lock-pool-branch))',
+            'pool': pool,
+        }
+        if 'lock-pool-private-key' in config_vars:
+            source['private_key'] = '((lock-pool-private-key))'
+        elif 'lock-pool-username' in config_vars:
+            source['username'] = '((lock-pool-username))'
+            source['password'] = '((lock-pool-password))'
         lock_resource = {
             'name': lock_resource_name,
             'type': 'pool',
-            'source': {
-                'uri': '((lock-pool-repo))',
-                'branch': '((lock-pool-branch))',
-                'pool': pool,
-                'private_key': '((lock-pool-private-key))',
-            }
+            'source': source,
         }
         resources.append(lock_resource)
 

--- a/tests/data/config-test/build_platforms.d/centos5-64.yml
+++ b/tests/data/config-test/build_platforms.d/centos5-64.yml
@@ -1,6 +1,7 @@
 label: centos5-64
 platform: linux
 arch: 64
+pool_name: centos5
 connector:
   image_resource:
     type: docker-image

--- a/tests/data/config-test/build_platforms.d/osx109.yml
+++ b/tests/data/config-test/build_platforms.d/osx109.yml
@@ -1,3 +1,4 @@
 label: osx-109
 platform: osx
 arch: 64
+pool_name: osx

--- a/tests/data/config-test/build_platforms.d/win64.yml
+++ b/tests/data/config-test/build_platforms.d/win64.yml
@@ -1,3 +1,4 @@
 label: win-32
 platform: win
 arch: 32
+pool_name: win

--- a/tests/data/config-test/config.yml
+++ b/tests/data/config-test/config.yml
@@ -12,4 +12,8 @@ intermediate-user: your-intermediate-user
 intermediate-private-key-job: key-to-upload-to-concourse
 intermediate-private-key: |
   private-key-to-use-for-connecting-to-intermediate-server
+lock-pool-repo: your-lock-pool-repo
+lock-pool-branch: master
+lock-pool-private-key: |
+  private-key-to-use-for-connecting-to-lock-pool-repo
 build_env_pkgs: /ci/build_pack

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -35,7 +35,7 @@ def test_submit_one_off(mocker):
                                                        output_dir=None, platform_filters=None,
                                                        worker_tags=None, clobber_sections_file=None,
                                                        append_sections_file=None, pass_throughs=[],
-                                                       skip_existing=True)
+                                                       skip_existing=True, use_lock_pool=False)
 
 
 def test_submit_batch(mocker):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,7 +6,8 @@ graph_data_dir = os.path.join(test_data_dir, 'graph_data')
 
 default_worker = {"platform": 'linux',
                   'arch': '64',
-                  'label': 'linux'}
+                  'label': 'linux',
+                  'pool_name': 'linux_pool'}
 
 
 def make_recipe(name, dependencies=()):


### PR DESCRIPTION
Use a pool of locks backed by a Git repository to limit the number of concurrent build tasks run on each build platform.  Once all locks are acquired additional jobs will wait until a lock in the appropriate pool becomes available and will then start.  By default a delay of 10 seconds is used before retrying to acquire a lock although this can be controlled by the `retry_delay` parameter of the lock resource.

Locks are acquired immediately before the build step and released regardless of the success of the build step. 

Locks are only used for the `one-off` sub-command when the `--use_lock_pool` argument is included.

This implementation requires the following additions to the concourse configuration files:
* each build worker configuration needs to include a `pool_name` entry which specifies the name of the pool from which locks will be acquired and released.
* The top level `config.yml` file must include `lock-pool-repo`, `lock-pool-branch` and `lock-pool-private-key` entries which specify the git repository which controls the resource.  Details on the layout of this repository can be found in the [pool-resource documentation](https://github.com/concourse/pool-resource).

Note that this does not route jobs to a particular workers.  This only limits the number of concurrent builds jobs on each platform. 