### PR TITLE
c3i batch accepts --use_lock_pool

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -210,6 +210,10 @@ def parse_args(parse_this=None):
         '--no-skip-existing', help="Do not skip existing builds",
         dest="skip_existing", action="store_false"
     )
+    batch_parser.add_argument(
+        '--use_lock_pool', help="Use the lock pool to limit jobs",
+        dest="use_lock_pool", action="store_true"
+    )
 
     rm_parser = sp.add_parser('rm', help='remove pipelines from server')
     rm_parser.add_argument('pipeline_names', nargs="+",

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -1027,6 +1027,7 @@ def submit_batch(
         batch_items = [BatchItem(line) for line in batch_lines]
 
     _ensure_login_and_sync(config_root_dir)
+    use_lock_pool = kwargs.get('use_lock_pool', False)
 
     config_path = os.path.expanduser(os.path.join(config_root_dir, 'config.yml'))
     with open(config_path) as src:
@@ -1037,7 +1038,11 @@ def submit_batch(
     success = []
     failed = []
     while len(batch_items):
-        num_activate_builds = _get_activate_builds(concourse_url, build_lookback)
+        if use_lock_pool:
+            print("Using lock pool, not limiting builds via submission")
+            num_activate_builds = max_builds - 1
+        else:
+            num_activate_builds = _get_activate_builds(concourse_url, build_lookback)
         if num_activate_builds < max_builds:
             # use a try/except block here so a single failed one-off does not
             # break the batch

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,7 +47,8 @@ def test_submit_batch(mocker):
         max_builds=36, poll_time=120, build_lookback=500, label_prefix='autobot_',
         debug=False, public=True, subparser_name='batch', channel=None,
         variant_config_files=None, output_dir=None, platform_filters=None, worker_tags=None,
-        clobber_sections_file=None, append_sections_file=None, pass_throughs=[], skip_existing=True)
+        clobber_sections_file=None, append_sections_file=None, use_lock_pool=False,
+        pass_throughs=[], skip_existing=True)
 
 
 def test_submit_without_base_name_raises():


### PR DESCRIPTION
c3i batch does not check the number of outstanding jobs if
the --use_lock_pool argument is passed as the pool resource is used to
limit concurrent jobs.