### PR TITLE
add --use-repo-access arg to one-off and batch

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -141,6 +141,11 @@ def parse_args(parse_this=None):
         '--use_lock_pool', help="Use the lock pool to limit jobs",
         dest="use_lock_pool", action="store_true"
     )
+    one_off_parser.add_argument(
+        '--use-repo-access',
+        help="Pass the repo access credentials to the workers",
+        action="store_true",
+    )
 
     batch_parser = sp.add_parser('batch', help="submit a batch of one-off jobs.")
     batch_parser.add_argument(
@@ -213,6 +218,11 @@ def parse_args(parse_this=None):
     batch_parser.add_argument(
         '--use_lock_pool', help="Use the lock pool to limit jobs",
         dest="use_lock_pool", action="store_true"
+    )
+    batch_parser.add_argument(
+        '--use-repo-access',
+        help="Pass the repo access credentials to the workers",
+        action="store_true",
     )
 
     rm_parser = sp.add_parser('rm', help='remove pipelines from server')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,15 +27,26 @@ def test_submit_one_off(mocker):
     mocker.patch.object(cli.execute, 'submit_one_off')
     args = ['one-off', 'frank', 'bzip2', '--config-root-dir', '../config']
     cli.main(args)
-    cli.execute.submit_one_off.assert_called_once_with(pipeline_label='frank',
-                                                       config_root_dir=mocker.ANY, debug=False,
-                                                       public=True, recipe_root_dir=os.getcwd(),
-                                                       subparser_name='one-off', folders=['bzip2'],
-                                                       channel=None, variant_config_files=None,
-                                                       output_dir=None, platform_filters=None,
-                                                       worker_tags=None, clobber_sections_file=None,
-                                                       append_sections_file=None, pass_throughs=[],
-                                                       skip_existing=True, use_lock_pool=False)
+    cli.execute.submit_one_off.assert_called_once_with(
+        pipeline_label='frank',
+        config_root_dir=mocker.ANY,
+        debug=False,
+        public=True,
+        recipe_root_dir=os.getcwd(),
+        subparser_name='one-off',
+        folders=['bzip2'],
+        channel=None,
+        variant_config_files=None,
+        output_dir=None,
+        platform_filters=None,
+        worker_tags=None,
+        clobber_sections_file=None,
+        append_sections_file=None,
+        pass_throughs=[],
+        skip_existing=True,
+        use_lock_pool=False,
+        use_repo_access=False,
+    )
 
 
 def test_submit_batch(mocker):
@@ -43,12 +54,28 @@ def test_submit_batch(mocker):
     args = ['batch', 'batch_file.txt', '--config-root-dir', '../config']
     cli.main(args)
     cli.execute.submit_batch.assert_called_once_with(
-        batch_file='batch_file.txt', recipe_root_dir=os.getcwd(), config_root_dir=mocker.ANY,
-        max_builds=36, poll_time=120, build_lookback=500, label_prefix='autobot_',
-        debug=False, public=True, subparser_name='batch', channel=None,
-        variant_config_files=None, output_dir=None, platform_filters=None, worker_tags=None,
-        clobber_sections_file=None, append_sections_file=None, use_lock_pool=False,
-        pass_throughs=[], skip_existing=True)
+        batch_file='batch_file.txt',
+        recipe_root_dir=os.getcwd(),
+        config_root_dir=mocker.ANY,
+        max_builds=36,
+        poll_time=120,
+        build_lookback=500,
+        label_prefix='autobot_',
+        debug=False,
+        public=True,
+        subparser_name='batch',
+        channel=None,
+        variant_config_files=None,
+        output_dir=None,
+        platform_filters=None,
+        worker_tags=None,
+        clobber_sections_file=None,
+        append_sections_file=None,
+        use_lock_pool=False,
+        use_repo_access=False,
+        pass_throughs=[],
+        skip_existing=True,
+    )
 
 
 def test_submit_without_base_name_raises():


### PR DESCRIPTION
Add the --use-repo-access argument to the one-off and batch subcommands.
This argument conditionally enables the repo access credentials
(username and token) to be passed to the build jobs. By default these
are not passed.

Writing the _netrc/.netrc can stall workers if another job is accessing or
writing the file at the same time. This effects windows especially. The
argument will not write these files unless they are specifically
required and requested by the user.