### PR TITLE
Automated pipeline flag

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -94,6 +94,11 @@ def parse_args(parse_this=None):
     one_off_parser.add_argument('folders', nargs="+",
                                 help=("Specify folders, relative to --recipe-root-dir, to upload "
                                       "and build"))
+    one_off_parser.add_argument('--automated-pipeline',
+                                action='store_true',
+                                default=False,
+                                help="Flag to run this one_off command as an automated pipeline. Default is False",
+                                )
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),
                                 help="path containing recipe folders to upload")
     one_off_parser.add_argument('--config-root-dir',

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -727,7 +727,6 @@ def build_automated_pipeline(resource_types, resources, remapped_jobs, folders):
                 }
             }
     # need to modify jobs
-    import pdb; pdb.set_trace()
     pass
 
 
@@ -967,8 +966,6 @@ def compute_builds(path, base_name, git_rev=None, stop_rev=None, folders=None, m
     if config_overrides:
         data.update(config_overrides)
     
-    import pdb; pdb.set_trace()
-
     plan = graph_to_plan_with_jobs(
         os.path.abspath(path),
         task_graph,

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -755,7 +755,6 @@ def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, 
 
     sync_after_pr_merge = {
         'name': 'sync-after-PR-merge',
-        'disable_manual_trigger': True,
         'plan': sync_after_pr_merge_plan
         }
 

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -690,7 +690,7 @@ def graph_to_plan_with_jobs(
 
 def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, order):
     # resources to add
-    deployment_approval = OrderedDict({
+    deployment_approval = {
             'name': 'deployment-approval',
             'type': 'git',
             'source': {
@@ -698,15 +698,15 @@ def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, 
                 'paths': ['recipe/meta.yaml'],
                 'uri': 'https://github.com/AnacondaRecipes/{}.git'.format(folders[0])
                 }
-            })
-    pull_recipes = OrderedDict({
+            }
+    pull_recipes = {
             'name': 'pull-recipes',
             'type': 'git',
-            'source': OrderedDict({
+            'source': {
                 'branch': 'automated-build',
                 'uri': 'https://github.com/AnacondaRecipes/{}.git'.format(folders[0])
-                })
-            })
+                }
+            }
     resources.append(deployment_approval)
     resources.append(pull_recipes)
 
@@ -719,24 +719,24 @@ def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, 
     rsyncs = ['rsync_{}'.format(i) for i in order if i.startswith(folders[0].split('-')[0])]
     inputs = []
 
-    sync_after_pr_merge_plan = [OrderedDict({'get': 'deployment-approval', 'trigger': True})]
+    sync_after_pr_merge_plan = [{'get': 'deployment-approval', 'trigger': True}]
     for i in rsyncs:
         if not i.startswith('test-'):
             sync_after_pr_merge_plan.append({'get': i})
             inputs.append({'name': i})
 
-    sync_the_thing_task = OrderedDict({
+    sync_the_thing_task = {
         'task': 'sync_the_thing',
-        'config': OrderedDict({
+        'config': {
             'platform': 'linux',
-            'image_resource': OrderedDict({
+            'image_resource': {
                 'type': 'docker-image',
-                'source': OrderedDict({
+                'source': {
                     'repository': 'conda/c3i-linux-64',
                     'tag': 'latest'
-                    })
-                }),
-            'run': OrderedDict({
+                    }
+                },
+            'run': {
                 'path': 'sh',
                 'args': [
                     '-exc',
@@ -746,18 +746,18 @@ def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, 
                      'echo "first run skipping"\n'
                      'fi'
                      )]
-                }),
+                },
             'inputs': inputs
-            })
-        })
+            }
+        }
 
     sync_after_pr_merge_plan.append(sync_the_thing_task)
 
-    sync_after_pr_merge = OrderedDict({
+    sync_after_pr_merge = {
         'name': 'sync-after-PR-merge',
         'disable_manual_trigger': True,
         'plan': sync_after_pr_merge_plan
-        })
+        }
 
     remapped_jobs.insert(0, sync_after_pr_merge)
 


### PR DESCRIPTION
This is really messy and absolutely needs to be cleaned up. 

It adds a flag, `--automated-pipeline`, to the one-off command that will change the pipeline to pull the recipe from github. It will then have a gated task that will only get ran when the master branch's meta.yaml gets updated. 
Right now that task does nothing, we should update this to make it do something more useful. Maybe it moves these packages to some staging area.