### PR TITLE
add branches flag

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -99,6 +99,11 @@ def parse_args(parse_this=None):
                                 default=False,
                                 help="Flag to run this one_off command as an automated pipeline. Default is False",
                                 )
+    one_off_parser.add_argument('--branches',
+                                nargs='+',
+                                default=None,
+                                help="List of branches that will be pulled from. You should either pass in one branch or n number of branches where n is equal to the number of recipes you are building.",
+                                )
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),
                                 help="path containing recipe folders to upload")
     one_off_parser.add_argument('--config-root-dir',

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -112,7 +112,7 @@ def parse_args(parse_this=None):
             "Specific this option after the list of folders to avoid "
             "confusing which arguments are folders and which are branches, "
             "for example: "
-            "c3i one-off folder1 folder2 --branches branch1 branch2"
+            "c3i one-off pipeline_label folder1 folder2 --branches branch1 branch2"
         )
     )
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -99,11 +99,22 @@ def parse_args(parse_this=None):
                                 default=False,
                                 help="Flag to run this one_off command as an automated pipeline. Default is False",
                                 )
-    one_off_parser.add_argument('--branches',
-                                nargs='+',
-                                default=None,
-                                help="List of branches that will be pulled from. You should either pass in one branch or n number of branches where n is equal to the number of recipes you are building.",
-                                )
+    one_off_parser.add_argument(
+        '--branches',
+        nargs='+',
+        default=None,
+        help=(
+            "Only used when --automated_pipeline is specified. "
+            "List of repository branches that recipes will be pulled from. "
+            "Either pass in one branch or n number of branches where "
+            "n is equal to the number of recipes you are building. "
+            "The default is to use the 'automated-build' branch. "
+            "Specific this option after the list of folders to avoid "
+            "confusing which arguments are folders and which are branches, "
+            "for example: "
+            "c3i one-off folder1 folder2 --branches branch1 branch2"
+        )
+    )
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),
                                 help="path containing recipe folders to upload")
     one_off_parser.add_argument('--config-root-dir',

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -792,7 +792,7 @@ def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, 
                     plan['config']['inputs'] = inputs
                     for n, i in enumerate(plan.get('config').get('inputs')):
                         if i.get('name') == 'rsync-recipes':
-                                del(plan['config']['inputs'][n])
+                            del(plan['config']['inputs'][n])
                 if plan.get('task', '') == 'test':
                     for resource in resources:
                         if resource.get('name').startswith('rsync_{}'.format(folders[0].split('-')[0])) and 'canary' not in resource.get('name'):

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -421,7 +421,7 @@ def sourceclear_task(meta, node, config_vars):
 def graph_to_plan_with_jobs(
         base_path, graph, commit_id, matrix_base_dir, config_vars, public=True,
         worker_tags=None, pass_throughs=None, use_lock_pool=False,
-        use_repo_access=False, automated_pipeline=False, branches=[], folders=None):
+        use_repo_access=False, automated_pipeline=False, branches=None, folders=None):
     used_pools = {}
     jobs = OrderedDict()
     # upload_config_path = os.path.join(matrix_base_dir, 'uploads.d')
@@ -690,7 +690,7 @@ def graph_to_plan_with_jobs(
 
 def build_automated_pipeline(resource_types, resources, remapped_jobs, folders, order, branches):
     # resources to add
-    if not branches:
+    if branches is None:
         branches = ['automated-build']
     for n, folder in enumerate(folders):
         if len(branches) == 1:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -47,6 +47,7 @@ def test_submit_one_off(mocker):
         use_lock_pool=False,
         use_repo_access=False,
         automated_pipeline=False,
+        branches=None,
     )
 
 


### PR DESCRIPTION
This PR adds the `--branches` flag. 
Using this flag you can either specify exactly one or n number of branches where n is equal to the number of feedstocks passed in.

If you do not pass in a branch it will default to the `automated-build` branch.

This still needs to figure out how to pull all of the correct things into the build tasks.