### PR TITLE
add optional stage_for_upload job

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -120,7 +120,8 @@ def parse_args(parse_this=None):
         help="create job that stages package for upload as part of the pipeline")
     one_off_parser.add_argument(
         '--commit-msg', action='store',
-        help="git commit message to record when packages are uploaded")
+        help=("git commit message to record when packages are uploaded, "
+              "required when --stage-for-upload specified"))
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),
                                 help="path containing recipe folders to upload")
     one_off_parser.add_argument('--config-root-dir',

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -115,6 +115,12 @@ def parse_args(parse_this=None):
             "c3i one-off pipeline_label folder1 folder2 --branches branch1 branch2"
         )
     )
+    one_off_parser.add_argument(
+        '--stage-for-upload', action='store_true',
+        help="create job that stages package for upload as part of the pipeline")
+    one_off_parser.add_argument(
+        '--commit-msg', action='store',
+        help="git commit message to record when packages are uploaded")
     one_off_parser.add_argument('--recipe-root-dir', default=os.getcwd(),
                                 help="path containing recipe folders to upload")
     one_off_parser.add_argument('--config-root-dir',

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -1005,10 +1005,7 @@ def add_upload_job(plan, data, commit_msg):
     # add PIPELINE and GIT_COMMIT_MSG to params
     params = config.get('params', {})
     params['PIPELINE'] = data['base-name']
-    if commit_msg is None:
-        params['GIT_COMMIT_MSG'] = "NA"
-    else:
-        params['GIT_COMMIT_MSG'] = commit_msg
+    params['GIT_COMMIT_MSG'] = commit_msg
     config['params'] = params
 
     job_plan.append({
@@ -1028,6 +1025,10 @@ def compute_builds(path, base_name, git_rev=None, stop_rev=None, folders=None, m
                    use_repo_access=False, **kw):
     if not git_rev and not folders:
         raise ValueError("Either git_rev or folders list are required to know what to compute")
+    if kw.get('stage_for_upload', False):
+        if kw.get('commit_msg') is None:
+            raise ValueError(
+                "--stage-for-upload requires --commit-msg to be specified")
     checkout_rev = stop_rev or git_rev
     folders = folders
     path = path.replace('"', '')
@@ -1095,7 +1096,7 @@ def compute_builds(path, base_name, git_rev=None, stop_rev=None, folders=None, m
         folders=folders
     )
     if kw.get('stage_for_upload', False):
-        add_upload_job(plan, data, kw.get('commit_msg'))
+        add_upload_job(plan, data, kw['commit_msg'])
 
     output_dir = output_dir.format(base_name=base_name, git_identifier=git_identifier)
 

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -1002,12 +1002,12 @@ def add_upload_job(plan, data, commit_msg):
         job_plan.append({'get': 'stage-packages-scripts', 'trigger': False})
 
     config = data.get('stage-for-upload-config')
-    # add ARTIFACT_DIR and GIT_COMMIT_MSG (when defined) to params
+    # add PIPELINE and GIT_COMMIT_MSG to params
     params = config.get('params', {})
-    artifact_dir = os.path.join(
-        data['intermediate-base-folder'], data['base-name'], 'artifacts')
-    params['ARTIFACT_DIR'] = artifact_dir
-    if commit_msg is not None:
+    params['PIPELINE'] = data['base-name']
+    if commit_msg is None:
+        params['GIT_COMMIT_MSG'] = "NA"
+    else:
         params['GIT_COMMIT_MSG'] = commit_msg
     config['params'] = params
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,8 @@ def test_submit_one_off(mocker):
         use_repo_access=False,
         automated_pipeline=False,
         branches=None,
+        stage_for_upload=False,
+        commit_msg=None,
     )
 
 


### PR DESCRIPTION
Add an optional "stage_for_upload" jobs to pipelines which executes the
task defined in the stage_for_upload_config section of the configuration
with the artifact directory passes in via the ARTIFACT_DIR environment
variable. This job is created when the --stage-for-upload option is
specified on the command line.

Additionally, adds a --commit-msg command line option where a git commit
message can be specified that is passed to the the upload job via the
GIT_COMMIT_MSG environment variable.