### PR TITLE
trigger upload and branch push via PR merge

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -126,6 +126,11 @@ def parse_args(parse_this=None):
         help="The git repo where the PR lives. This should look like: Org/Repo"
     )
     one_off_parser.add_argument(
+        "--pr-file",
+        action="store",
+        help="File added to the git repo by the PR"
+    )
+    one_off_parser.add_argument(
         '--stage-for-upload', action='store_true',
         help="create job that stages package for upload as part of the pipeline")
     one_off_parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -53,6 +53,7 @@ def test_submit_one_off(mocker):
         stage_for_upload=False,
         commit_msg=None,
         pr_num=None,
+        pr_file=None,
         repository=None,
     )
 


### PR DESCRIPTION
Trigger the stage_for_upload and push_branch_... jobs when the file
specified in the --pr-file command line option appears in the git
repository specified in the pr-repo configuration option. The
expectation is that when this file appears when the PR for the
particular pipeline is merged.