### PR TITLE
Get c3i working with a successful concourse update with tagging

### DIFF
--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -54,7 +54,7 @@ def parse_args(parse_this=None):
     examine_parser.add_argument('--worker-tag', '-t', action='append',
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
-                                "meta.yaml with selectors.",
+                                "meta.yaml with selectors. Default is 'all'.",
                                 dest='worker_tags', default='all')
     examine_parser.add_argument(
         '-m', '--variant-config-files',
@@ -162,7 +162,7 @@ def parse_args(parse_this=None):
     one_off_parser.add_argument('--worker-tag', '-t', action='append',
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
-                                "meta.yaml with selectors.",
+                                "meta.yaml with selectors. Default is 'all'.",
                                 dest='worker_tags', default='all')
     one_off_parser.add_argument(
         '-m', '--variant-config-files',
@@ -250,7 +250,7 @@ def parse_args(parse_this=None):
     batch_parser.add_argument('--worker-tag', '-t', action='append',
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
-                                "meta.yaml with selectors.",
+                                "meta.yaml with selectors. Default is 'all'.",
                                 dest='worker_tags', default='all')
     batch_parser.add_argument(
         '-m', '--variant-config-files',

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -55,7 +55,7 @@ def parse_args(parse_this=None):
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
                                 "meta.yaml with selectors. Default is 'all'.",
-                                dest='worker_tags', default='all')
+                                dest='worker_tags', default=['all'])
     examine_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",
@@ -163,7 +163,7 @@ def parse_args(parse_this=None):
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
                                 "meta.yaml with selectors. Default is 'all'.",
-                                dest='worker_tags', default='all')
+                                dest='worker_tags', default=['all'])
     one_off_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",
@@ -251,7 +251,7 @@ def parse_args(parse_this=None):
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
                                 "meta.yaml with selectors. Default is 'all'.",
-                                dest='worker_tags', default='all')
+                                dest='worker_tags', default=['all'])
     batch_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",

--- a/conda_concourse_ci/cli.py
+++ b/conda_concourse_ci/cli.py
@@ -55,7 +55,7 @@ def parse_args(parse_this=None):
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
                                 "meta.yaml with selectors.",
-                                dest='worker_tags')
+                                dest='worker_tags', default='all')
     examine_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",
@@ -163,7 +163,7 @@ def parse_args(parse_this=None):
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
                                 "meta.yaml with selectors.",
-                                dest='worker_tags')
+                                dest='worker_tags', default='all')
     one_off_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",
@@ -251,7 +251,7 @@ def parse_args(parse_this=None):
                                 help="set worker tag(s) to limit where jobs will run.  Applies "
                                 "to all jobs.  For finer control, use extra/worker_tags in "
                                 "meta.yaml with selectors.",
-                                dest='worker_tags')
+                                dest='worker_tags', default='all')
     batch_parser.add_argument(
         '-m', '--variant-config-files',
         action="append",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_submit_one_off(mocker):
         variant_config_files=None,
         output_dir=None,
         platform_filters=None,
-        worker_tags=None,
+        worker_tags=['all'],
         push_branch=False,
         destroy_pipeline=False,
         clobber_sections_file=None,
@@ -78,7 +78,7 @@ def test_submit_batch(mocker):
         variant_config_files=None,
         output_dir=None,
         platform_filters=None,
-        worker_tags=None,
+        worker_tags=['all'],
         clobber_sections_file=None,
         append_sections_file=None,
         use_lock_pool=False,
@@ -119,7 +119,7 @@ def test_examine(mocker):
                                                        path='.', steps=0, stop_rev=None,
                                                        subparser_name='examine', test=False,
                                                        channel=None, variant_config_files=None,
-                                                       platform_filters=None, worker_tags=None,
+                                                       platform_filters=None, worker_tags=['all'],
                                                        pass_throughs=[], skip_existing=True)
 
 


### PR DESCRIPTION
To ensure we don't break our usual workflow (users don't have to specify --worker-tag in order to kick off general builds), we need a default value for the --worker-tag. The default should be an array with a single value containing the tag that each worker shares.