### PR TITLE
point at package for testing

### DIFF
--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -228,7 +228,13 @@ def get_build_task(
     stepconfig.cb_args.extend(ensure_list(pass_throughs))
     # this is the recipe path to build
     if automated_pipeline:
-        stepconfig.cb_args.append('combined_recipe')
+        if test_only:
+            # when we test we should point directly at the tar.bz2 instead
+            # of at the recipe
+            stepconfig.cb_args.append('indexed-artifacts/*/*.tar.bz2')
+        else:
+            # when we build we should just point at the recipe
+            stepconfig.cb_args.append('combined_recipe')
     else:
         stepconfig.cb_args.append(os.path.join('rsync-recipes', node))
     if use_staging_channel:


### PR DESCRIPTION
This fixes win-32 testing and also points at the .tar.bz2 for testing instead of the recipe which was deprecated in conda-build 3.16.0