### PR TITLE
Set check_every to 1 hour on docker-image

### DIFF
--- a/ci/pack-build-env.yaml
+++ b/ci/pack-build-env.yaml
@@ -2,11 +2,12 @@
 resource_types:
 - name: rsync-resource
   type: docker-image
+  check_every: 1h
   source:
-      repository: conda/concourse-rsync-resource
-      tag: latest
-      username: ((common.dockerhub-user))
-      password: ((common.dockerhub-pass))
+    repository: conda/concourse-rsync-resource
+    tag: latest
+    username: ((common.dockerhub-user))
+    password: ((common.dockerhub-pass))
 
 resources:
 - name: once-a-week

--- a/conda_concourse_ci/bootstrap/config/build_platforms.d/example.yml
+++ b/conda_concourse_ci/bootstrap/config/build_platforms.d/example.yml
@@ -5,6 +5,7 @@ arch: 64
 connector:
   image_resource:
     type: docker-image
+    check_every: 1h
     source:
       repository: conda/c3i-linux-64
       tag: latest

--- a/conda_concourse_ci/bootstrap/config/test_platforms.d/example.yml
+++ b/conda_concourse_ci/bootstrap/config/test_platforms.d/example.yml
@@ -5,6 +5,7 @@ arch: 64
 connector:
   image_resource:
     type: docker-image
+    check_every: 1h
     source:
       repository: conda/c3i-linux-64
       tag: latest

--- a/conda_concourse_ci/bootstrap/plan_director.yml
+++ b/conda_concourse_ci/bootstrap/plan_director.yml
@@ -1,6 +1,7 @@
 resource_types:
 - name: rsync-resource
   type: docker-image
+  check_every: 1h
   source:
       repository: conda/concourse-rsync-resource
       tag: latest
@@ -50,6 +51,7 @@ jobs:
           - name: recipe-repo-source
         image_resource:
           type: docker-image
+          check_every: 1h
           source:
             repository: conda/c3i-linux-64
             username: ((common.dockerhub-user))
@@ -70,6 +72,7 @@ jobs:
           - name: recipe-repo-source
         image_resource:
           type: docker-image
+          check_every: 1h
           source:
             repository: conda/c3i-linux-64
             username: ((common.dockerhub-user))
@@ -107,6 +110,7 @@ jobs:
         - name: output
       image_resource:
         type: docker-image
+        check_every: 1h
         source:
           repository: conda/c3i-linux-64
           username: ((common.dockerhub-user))
@@ -141,6 +145,7 @@ jobs:
         - name: output
       image_resource:
         type: docker-image
+        check_every: 1h
         source:
           repository: conda/c3i-linux-64
           username: ((common.dockerhub-user))

--- a/docker/build_job.yml
+++ b/docker/build_job.yml
@@ -15,6 +15,7 @@ jobs:
           username: {{docker-hub-username}}
           password: {{docker-hub-password}}
         type: docker-image
+        check_every: 1h
       inputs:
       - name: recipe-repo-source
       platform: linux
@@ -37,6 +38,7 @@ jobs:
           repository: conda/c3i-linux-64
           tag: latest
         type: docker-image
+        check_every: 1h
       inputs:
         - name: recipe-repo-source
       outputs:
@@ -56,6 +58,7 @@ jobs:
 resources:
 - name: docker-image
   type: docker-image
+  check_every: 1h
   source:
     username: {{docker-hub-username}}
     password: {{docker-hub-password}}

--- a/tests/data/config-test/build_platforms.d/centos5-64.yml
+++ b/tests/data/config-test/build_platforms.d/centos5-64.yml
@@ -5,6 +5,7 @@ pool_name: centos5
 connector:
   image_resource:
     type: docker-image
+    check_every: 1h
     source:
       repository: busybox
       username: ((common.dockerhub-user))

--- a/tests/data/linux-config-test/build_platforms.d/centos5-64.yml
+++ b/tests/data/linux-config-test/build_platforms.d/centos5-64.yml
@@ -4,6 +4,7 @@ arch: 64
 connector:
   image_resource:
     type: docker-image
+    check_every: 1h
     source:
       repository: busybox
       username: ((common.dockerhub-user))

--- a/tests/data/plan_director.yml
+++ b/tests/data/plan_director.yml
@@ -1,17 +1,20 @@
 resource_types:
 - name: concourse-pipeline
   type: docker-image
+  check_every: 1h
   source:
     repository: robdimsdale/concourse-pipeline-resource
     tag: latest-final
 # used to download arbitrary user configuration (credentials, platforms)
 - name: s3-simple
   type: docker-image
+  check_every: 1h
   source:
     repository: 18fgsa/s3-resource-simple
 # used to check for PRs and update status at Github
 - name: pull-request
   type: docker-image
+  check_every: 1h
   source:
     repository: jtarchie/pr
 
@@ -90,6 +93,7 @@ jobs:
         - name: output
       image_resource:
         type: docker-image
+        check_every: 1h
         source:
           repository: conda/c3i-linux-64
           username: ((common.dockerhub-user))


### PR DESCRIPTION
In order to fix dockerhub's request for more money based on our usage,
we want to reduce that usage. This is an attempt to do that by checking
only every 1 hour.

* Fixes inconsistent indentation on one source block
* Adds `check_every: 1h` to all docker-image resources