### PR TITLE
Using new ECR build image.

### DIFF
--- a/conda_concourse_ci/bootstrap/plan_director.yml
+++ b/conda_concourse_ci/bootstrap/plan_director.yml
@@ -51,9 +51,8 @@ jobs:
           type: docker-image
           check_every: 1h
           source:
-            repository: continuumio/anaconda-pkg-build
-            username: ((common.dockerhub-user))
-            password: ((common.dockerhub-pass))
+            repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+            tag: master-amd64
         params:
           GITHUB_TOKEN: ((recipe-repo-access-token))
         run:
@@ -72,9 +71,8 @@ jobs:
           type: docker-image
           check_every: 1h
           source:
-            repository: continuumio/anaconda-pkg-build
-            username: ((common.dockerhub-user))
-            password: ((common.dockerhub-pass))
+            repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+            tag: master-amd64
         params:
           GITHUB_TOKEN: ((recipe-repo-access-token))
         run:
@@ -110,9 +108,8 @@ jobs:
         type: docker-image
         check_every: 1h
         source:
-          repository: continuumio/anaconda-pkg-build
-          username: ((common.dockerhub-user))
-          password: ((common.dockerhub-pass))
+          repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tag: master-amd64
       platform: linux
       run:
         # this should output plan.yaml (credentials baked in) and recipes.  These will be in a folder
@@ -145,9 +142,8 @@ jobs:
         type: docker-image
         check_every: 1h
         source:
-          repository: continuumio/anaconda-pkg-build
-          username: ((common.dockerhub-user))
-          password: ((common.dockerhub-pass))
+          repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tag: master-amd64
       platform: linux
       run:
         path: c3i

--- a/conda_concourse_ci/concourse_config.py
+++ b/conda_concourse_ci/concourse_config.py
@@ -396,10 +396,8 @@ class JobConfig:
 
     def add_consolidate_task(self, inputs, subdir, docker_user=None, docker_pass=None):
         _source = {
-                    'repository': 'continuumio/anaconda-pkg-build',
-                    'tag': 'latest',
-                    'username': '((common.dockerhub-user))',
-                    'password': '((common.dockerhub-pass))'
+                    'repository': 'public.ecr.aws/y0o4y9o3/anaconda-pkg-build',
+                    'tag': 'master-amd64',
                     }
         if docker_user and docker_pass:
             _source.update({
@@ -434,10 +432,8 @@ class JobConfig:
         outputs = [{'name': 'converted-artifacts'}]
 
         _source = {
-                    'repository': 'continuumio/anaconda-pkg-build',
-                    'tag': 'latest',
-                    'username': '((common.dockerhub-user))',
-                    'password': '((common.dockerhub-pass))'
+                    'repository': 'public.ecr.aws/y0o4y9o3/anaconda-pkg-build',
+                    'tag': 'master-amd64',
                 }
         if docker_user and docker_pass:
             _source.update({

--- a/conda_concourse_ci/uploads.py
+++ b/conda_concourse_ci/uploads.py
@@ -26,10 +26,8 @@ def _base_task(upload_job_name, username=None, password=None):
                 'image_resource': {
                     'type': 'docker-image',
                     'source': {
-                        'repository': 'continuumio/anaconda-pkg-build',
-                        'tag': 'latest',
-                        'username': '((common.dockerhub-user))',
-                        'password': '((common.dockerhub-pass))'
+                        'repository': 'public.ecr.aws/y0o4y9o3/anaconda-pkg-build',
+                        'tag': 'master-amd64',
                     }
                 },
                 'platform': 'linux',

--- a/docker/build_job.yml
+++ b/docker/build_job.yml
@@ -10,10 +10,8 @@ jobs:
       image_resource:
         source:
           # can't template just part of a line: https://github.com/concourse/concourse/issues/545
-          repository: continuumio/anaconda-pkg-build
-          tag: latest
-          username: {{docker-hub-username}}
-          password: {{docker-hub-password}}
+          repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tag: master-amd64
         type: docker-image
         check_every: 1h
       inputs:
@@ -33,10 +31,8 @@ jobs:
       platform: linux
       image_resource:
         source:
-          repository: continuumio/anaconda-pkg-build
-          tag: latest
-          username: {{docker-hub-username}}
-          password: {{docker-hub-password}}
+          repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+          tag: master-amd64
         type: docker-image
         check_every: 1h
       inputs:
@@ -60,10 +56,8 @@ resources:
   type: docker-image
   check_every: 1h
   source:
-    repository: continuumio/anaconda-pkg-build
-    tag: latest
-    username: {{docker-hub-username}}
-    password: {{docker-hub-password}}
+    repository: public.ecr.aws/y0o4y9o3/anaconda-pkg-build
+    tag: master-amd64
     # can't template just part of a line: https://github.com/concourse/concourse/issues/545
 
 - name: recipe-repo-source


### PR DESCRIPTION
Moving the package building images back to ECR now that a non-manifest list exists.

Tested these changes on the following feedstocks:
- botocore-feedstock (noarch)
- curl-feedstock