### PR TITLE
Adds a package signing task

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - conda
     - contextlib2
     - networkx >=2.0
-    - pynacl
     - python
     - requests
     # we use pkg_resources, so yes, this is a runtime dep

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,6 +19,7 @@ requirements:
     - conda
     - contextlib2
     - networkx >=2.0
+    - pynacl
     - python
     - requests
     # we use pkg_resources, so yes, this is a runtime dep

--- a/conda_concourse_ci/concourse_config.py
+++ b/conda_concourse_ci/concourse_config.py
@@ -377,7 +377,7 @@ class JobConfig:
         self.plan.append({
             'put': resource_name,
             'params': {
-                'sync_dir': 'converted-artifacts',
+                'sync_dir': 'signed-artifacts',
                 'rsync_opts': [
                     "--archive",
                     "--no-perms",
@@ -458,13 +458,51 @@ class JobConfig:
                         'mkdir -p converted-artifacts/noarch\n'
                         'find . -name "converted-artifacts" -prune -o -path "*/{subdir}/*.tar.bz2" -print0 | xargs -0 -I file mv file converted-artifacts/{subdir}\n'  # NOQA
                         'find . -name "converted-artifacts" -prune -o -path "*/noarch/*.tar.bz2" -print0 | xargs -0 -I file mv file converted-artifacts/noarch\n'  # NOQA
-                'pushd converted-artifacts/{subdir} && cph t "*.tar.bz2" .conda && popd\n'
-                'pushd converted-artifacts/noarch && cph t "*.tar.bz2" .conda && popd\n'
+                        'pushd converted-artifacts/{subdir} && cph t "*.tar.bz2" .conda && popd\n'  # NOQA
+                        'pushd converted-artifacts/noarch && cph t "*.tar.bz2" .conda && popd\n'  # NOQA
                     .format(subdir=subdir)
                     ],
             }
         }
         self.plan.append({'task': 'convert .tar.bz2 to .conda', 'config': config})
+
+    def add_sign_artifacts_task(self, subdir, signing_key, docker_user=None, docker_pass=None):
+        _source = {
+            'repository': 'public.ecr.aws/y0o4y9o3/anaconda-pkg-build',
+            'tag': 'master-amd64',
+        }
+        if docker_user and docker_pass:
+            _source.update({
+                'username': docker_user,
+                'password': docker_pass
+            })
+        config = {
+            'platform': 'linux',
+            'inputs': [{'name': 'converted-artifacts'}],
+            'outputs': [{'name': 'signed-artifacts'}],
+            'image_resource': {
+                'type': 'docker-image',
+                'source': _source,
+            },
+            'run': {
+                'path': 'sh',
+                'args': [
+                    '-exc',
+                        'mkdir -p signed-artifacts/{subdir}\n'
+                        'mkdir -p signed-artifacts/noarch\n'
+                        'find . -name "signed-artifacts" -prune -o -path "*/{subdir}/*.tar.bz2" -print0 | xargs -0 -I file mv file signed-artifacts/{subdir}\n'  # NOQA
+                        'find . -name "signed-artifacts" -prune -o -path "*/noarch/*.tar.bz2" -print0 | xargs -0 -I file mv file signed-artifacts/noarch\n'  # NOQA
+                        'pushd signed-artifacts/{subdir} && TODO_SIGN_ARTIFACTS && popd\n'  # NOQA
+                        'pushd signed-artifacts/noarch && TODO_SIGN_ARTIFACTS && popd\n'  # NOQA
+                    .format(subdir=subdir)
+                ],
+            }
+        }
+        self.plan.append({
+            'task': 'sign artifacts with Concourse package signing key',
+            'config': config,
+        })
+
 
 
 class BuildStepConfig:

--- a/conda_concourse_ci/concourse_config.py
+++ b/conda_concourse_ci/concourse_config.py
@@ -492,6 +492,10 @@ class JobConfig:
                         'mkdir -p signed-artifacts/noarch\n'
                         'find . -name "signed-artifacts" -prune -o -path "*/{subdir}/*.tar.bz2" -print0 | xargs -0 -I file mv file signed-artifacts/{subdir}\n'  # NOQA
                         'find . -name "signed-artifacts" -prune -o -path "*/noarch/*.tar.bz2" -print0 | xargs -0 -I file mv file signed-artifacts/noarch\n'  # NOQA
+                        'find . -name "signed-artifacts" -prune -o -path "*/{subdir}/*.conda" -print0 | xargs -0 -I file mv file signed-artifacts/{subdir}\n'  # NOQA
+                        'find . -name "signed-artifacts" -prune -o -path "*/noarch/*.conda" -print0 | xargs -0 -I file mv file signed-artifacts/noarch\n'  # NOQA
+                        'find . -name "signed-artifacts" -prune -o -path "*/{subdir}/*.sig" -print0 | xargs -0 -I file mv file signed-artifacts/{subdir}\n'  # NOQA
+                        'find . -name "signed-artifacts" -prune -o -path "*/noarch/*.sig" -print0 | xargs -0 -I file mv file signed-artifacts/noarch\n'  # NOQA
                         'pushd signed-artifacts/{subdir} && TODO_SIGN_ARTIFACTS && popd\n'  # NOQA
                         'pushd signed-artifacts/noarch && TODO_SIGN_ARTIFACTS && popd\n'  # NOQA
                     .format(subdir=subdir)

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -196,6 +196,7 @@ def get_build_task(
         use_staging_channel=False,
         automated_pipeline=False,
         pull_recipes_resource=None,
+        sign_artifacts=True,
         ):
 
     worker_tags = (ensure_list(worker_tags) +
@@ -351,8 +352,17 @@ def graph_to_plan_with_jobs(
             pull_recipes_resource=pull_recipes_resource,
         ))
         if not test_only:
-            jobconfig.add_convert_task(meta.config.host_subdir,
-                    docker_user=docker_user, docker_pass=docker_pass)
+            jobconfig.add_convert_task(
+                meta.config.host_subdir,
+                docker_user=docker_user,
+                docker_pass=docker_pass,
+            )
+            jobconfig.add_sign_artifacts_task(
+                meta.config.host_subdir,
+                signing_key=config_vars['concourse-package-signing-key'],
+                docker_user=docker_user,
+                docker_pass=docker_pass,
+            )
             resource_name = 'rsync_' + node
             jobconfig.add_put_artifacts(resource_name)
             plconfig.add_rsync_packages(resource_name, config_vars)

--- a/conda_concourse_ci/execute.py
+++ b/conda_concourse_ci/execute.py
@@ -196,7 +196,6 @@ def get_build_task(
         use_staging_channel=False,
         automated_pipeline=False,
         pull_recipes_resource=None,
-        sign_artifacts=True,
         ):
 
     worker_tags = (ensure_list(worker_tags) +


### PR DESCRIPTION
Adds a task to create package signatures for all built artifacts.

### TODO

 - [ ] create a `repodata.json` to mimic prefect's feedstock build flow
 - [ ] create and insert an ed25519 signing key on all concourse builders
 - [ ] create a single script that will sign the files to be uploaded